### PR TITLE
[env] prisma model merge 코드 작성 및 테스트 완료

### DIFF
--- a/models/basic/base.prisma
+++ b/models/basic/base.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider = "prisma-client-js"
+    output   = "../generated/prisma"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}

--- a/models/customers.prisma
+++ b/models/customers.prisma
@@ -1,0 +1,4 @@
+model Customers{
+    id Int @id @default(autoincrement())
+    name String @db.VarChar(50)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@prisma/client": "^6.12.0",
         "dotenv": "^17.0.0",
         "express": "^5.1.0"
       },
       "devDependencies": {
         "@types/dotenv": "^6.1.1",
         "@types/express": "^5.0.3",
+        "prisma": "^6.12.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -58,6 +60,88 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.12.0.tgz",
+      "integrity": "sha512-wn98bJ3Cj6edlF4jjpgXwbnQIo/fQLqqQHPk2POrZPxTlhY3+n90SSIF3LMRVa8VzRFC/Gec3YKJRxRu+AIGVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.12.0.tgz",
+      "integrity": "sha512-HovZWzhWEMedHxmjefQBRZa40P81N7/+74khKFz9e1AFjakcIQdXgMWKgt20HaACzY+d1LRBC+L4tiz71t9fkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.12.0.tgz",
+      "integrity": "sha512-plbz6z72orcqr0eeio7zgUrZj5EudZUpAeWkFTA/DDdXEj28YHDXuiakvR6S7sD6tZi+jiwQEJAPeV6J6m/tEQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.12.0.tgz",
+      "integrity": "sha512-4BRZZUaAuB4p0XhTauxelvFs7IllhPmNLvmla0bO1nkECs8n/o1pUvAVbQ/VOrZR5DnF4HED0PrGai+rIOVePA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.12.0",
+        "@prisma/engines-version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+        "@prisma/fetch-engine": "6.12.0",
+        "@prisma/get-platform": "6.12.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc.tgz",
+      "integrity": "sha512-70vhecxBJlRr06VfahDzk9ow4k1HIaSfVUT3X0/kZoHCMl9zbabut4gEXAyzJZxaCGi5igAA7SyyfBI//mmkbQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.12.0.tgz",
+      "integrity": "sha512-EamoiwrK46rpWaEbLX9aqKDPOd8IyLnZAkiYXFNuq0YsU0Z8K09/rH8S7feOWAVJ3xzeSgcEJtBlVDrajM9Sag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.12.0",
+        "@prisma/engines-version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+        "@prisma/get-platform": "6.12.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.12.0.tgz",
+      "integrity": "sha512-nRerTGhTlgyvcBlyWgt8OLNIV7QgJS2XYXMJD1hysorMCuLAjuDDuoxmVt7C2nLxbuxbWPp7OuFRHC23HqD9dA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.12.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -694,6 +778,16 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -816,6 +910,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.12.0.tgz",
+      "integrity": "sha512-pmV7NEqQej9WjizN6RSNIwf7Y+jeh9mY1JEX2WjGxJi4YZWexClhde1yz/FuvAM+cTwzchcMytu2m4I6wPkIzg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.12.0",
+        "@prisma/engines": "6.12.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/proxy-addr": {
@@ -1107,7 +1227,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "tsc --clean",
     "start": "node dist/app.js",
-    "dev": "nodemon --watch 'src/**/*.ts' --exec ts-node src/app.ts"
+    "dev": "nodemon --watch 'src/**/*.ts' --exec ts-node src/app.ts",
+    "prisma:merge": "ts-node ./src/utils/mergeSchemas.ts",
+    "prisma:migrate": "npm run prisma:merge && prisma migrate dev --schema=prisma/schema.prisma",
+    "prisma:generate": "npm run prisma:merge && prisma generate --schema=prisma/schema.prisma"
   },
   "repository": {
     "type": "git",
@@ -21,12 +24,14 @@
   },
   "homepage": "https://github.com/jrkgus413/nb2-dearcarmate-team1#readme",
   "dependencies": {
+    "@prisma/client": "^6.12.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0"
   },
   "devDependencies": {
     "@types/dotenv": "^6.1.1",
     "@types/express": "^5.0.3",
+    "prisma": "^6.12.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,16 @@
+generator client {
+    provider = "prisma-client-js"
+    output   = "../generated/prisma"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+// ===== customers.prisma =====
+
+model Customers{
+    id Int @id @default(autoincrement())
+    name String @db.VarChar(50)
+}

--- a/src/utils/mergeSchemas.ts
+++ b/src/utils/mergeSchemas.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+
+const baseFile = path.join(__dirname, '../..', 'models', 'basic', 'base.prisma');
+const fragmentsDir = path.join(__dirname, '../..', 'models');
+const outputFile = path.join(__dirname, '../..', 'prisma', 'schema.prisma');
+
+const mergeSchemas = () => {
+    try {
+        let schema = fs.readFileSync(baseFile, 'utf-8');
+
+        const fragmentFiles = fs
+            .readdirSync(fragmentsDir)
+            .filter(file => file.endsWith('.prisma'))
+            .sort();
+
+        for (const file of fragmentFiles) {
+            const content = fs.readFileSync(path.join(fragmentsDir, file), 'utf-8');
+            schema += `\n\n// ===== ${file} =====\n\n` + content;
+        }
+
+        fs.writeFileSync(outputFile, schema);
+        console.log(`✅ schema.prisma has been generated at ${outputFile}`);
+    } catch (err) {
+        console.error('❌ Failed to merge schema files:', err);
+        process.exit(1);
+    }
+};
+
+mergeSchemas();


### PR DESCRIPTION
## 📝 요구사항
- 정의된 모델(*.prisma)들을 schema.prisma로 merge한다.

## ✨ 변경사항
- 추가로 필요한 ts-node, typescript, prisma, prisma_client 설치
- src 밖에 models를 두고 내부에 basic/base.prisma에 db에 대한 정보를 넣음(datastore, generator)

## 🔍 변경 이유
- prisma 내부에 한 파일로 몰아넣으니까 동일한 코드가 있다고 해서 밖으로 아예 빼내었다. prisma도 src와 동일한 위치에 있길래, models를 만들어서 내부에 모델 파일을 넣을 수 있게 하였다.
- models 내부에 basic을 따로 만들어서 기능 모델과 구분되도록 하였다. ts 파일 내부에 만들어 줄 수도 있겠으나, 모델은 따로 관리하는 것이 맞는 것 같아서 내부에 하드코딩 하지 않았다.

## ✅ 테스트 항목 (선택)
```bash
npm run prisma:migrate
```

## 🚨 주의 사항
- 아직 환경만 구축해서 테이블은 잘 만들어지지 않은 상태이다.

## 🔗 관련 이슈 (선택)
- fork해서 작업하고 있었는데 계속 디스코드 보내는데 실패한다.

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
