### PR TITLE
[feat] Prisma 모델 파일 병합 로직 개선

### DIFF
--- a/prisma/merge-schema.js
+++ b/prisma/merge-schema.js
@@ -15,6 +15,10 @@ datasource db {
 const modelDir = path.join(__dirname, 'models');
 const modelFiles = fs.readdirSync(modelDir);
 
-const mergedModels = modelFiles.map((file) => fs.readFileSync(path.join(modelDir, file), 'utf8')).join('\n\n');
+const mergedModels = modelFiles.map((file) => {
+  const content = fs.readFileSync(path.join(modelDir, file), 'utf8');
+  const replaced = content.replace(/(Model)\b/, '');
+  return replaced;
+}).join('\n\n');
 
 fs.writeFileSync(path.join(__dirname, 'schema.prisma'), schemaHeader + '\n' + mergedModels);


### PR DESCRIPTION
## 📝 요구사항
- [x] Prisma 폴더 내 선언된 모델명 중복으로 인한 처리

## ✨ 변경사항
- 병합 시 Model을 빈 문자열로 치환하도록 수정

## 🔍 변경 이유
- Prisma 폴더 내에 개별 스키마 파일과 메인 스키마 파일에서 중복 모델 선언으로 에러메세지 출력

## ✅ 테스트 항목 (선택)
- 메인 스키마 파일에 변경된 모델명으로 선언되어 중복 에러 발생하지 않음 확인
- 마이그레이션 정상 실행 확인

## 🚨 주의 사항
- 개별 Schema 모델명 {기능명}+Model로 수정 필요

## 🔗 관련 이슈 (선택)
- 관련 이슈: #25 

## ✅ 체크리스트 
- [ ] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [ ] 코드 리뷰를 위한 설명이 충분한가요?
- [ ] 관련 이슈를 링크했나요?
