### PR TITLE
fix: prisma Customer 스키마 수정

### DIFF
--- a/prisma/models/customer.prisma.part
+++ b/prisma/models/customer.prisma.part
@@ -1,13 +1,13 @@
 model Customer {
   id          BigInt   @id @default(autoincrement())
   name        String   @db.VarChar(50)
-  gender      Gender
+  gender      String   @db.Char(6)
   
   phoneNumber String   @unique @db.VarChar(13)
   email       String   @unique @db.VarChar(50)
 
-  ageGroup    Age
-  region      Region
+  ageGroup    String   @db.Char(7)
+  region      String   @db.Char(7)
   memo        String?
 
   createdAt   DateTime @default(now()) @db.Timestamp()
@@ -20,40 +20,4 @@ model Customer {
   company   Company  @relation(fields: [companyId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   contracts Contract[]
-}
-
-enum Gender {
-  MALE    @map("male")
-  FEMALE  @map("female")
-}
-
-enum Region {
-  SEOUL      @map("서울")
-  GYEONGGI   @map("경기")
-  INCHEON    @map("인천")
-  GANGWON    @map("강원")
-  CHUNGBUK   @map("충북")
-  CHUNGNAM   @map("충남")
-  SEJONG     @map("세종")
-  DAEJEON    @map("대전")
-  JEONBUK    @map("전북")
-  JEONNAM    @map("전남")
-  GWANGJU    @map("광주")
-  GYEONGBUK  @map("경북")
-  GYEONGNAM  @map("경남")
-  DAEGU      @map("대구")
-  ULSAN      @map("울산")
-  BUSAN      @map("부산")
-  JEJU       @map("제주")
-}
-
-enum Age {
-  TEN     @map("10")
-  TWENTY  @map("20")
-  THIRTY  @map("30")
-  FORTY   @map("40")
-  FIFTY   @map("50")
-  SIXTY   @map("60")
-  SEVENTY @map("70")
-  EIGHTY  @map("80")
 }


### PR DESCRIPTION
## 📝 요구사항
- customer의 스키마에서 enum을 삭제하고 필드의 데이터 타입을 string으로 변경한다.

## ✨ 변경사항
- prisma의 customer part 스키마 파일에서 enum을 제거하고 ageGroup, gender, region의 데이터 타입을 변경하였다.
<img width="498" height="191" alt="image" src="https://github.com/user-attachments/assets/67c3100f-a8b3-4d4e-8309-16097e18eb13" />

## 🔍 변경 이유
- 원래 enum 내부 값이 실제 사용 값이랑 동일해야 하는데, 달라서 발생했던 문제가 발생하고 enum이 숫자로 시작할 수 없다.

## ✅ 테스트 항목 (선택)
- `npm run dev`

## 🚨 주의 사항

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #75 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
