### PR TITLE
feat: 계약서 껍데기 코드 추가. 로직은 아직임

### DIFF
--- a/prisma/models/contract-document.prisma.part
+++ b/prisma/models/contract-document.prisma.part
@@ -4,6 +4,7 @@ model ContractDocument {
   
   contractId  BigInt   
   fileId      BigInt
+  fileName    String
 
   contract    Contract @relation(fields: [contractId], references: [id], onDelete: Cascade)
   

--- a/prisma/models/contract.prisma.part
+++ b/prisma/models/contract.prisma.part
@@ -1,12 +1,14 @@
 model Contract {
   id BigInt @id @default(autoincrement())
 
+  contractName String
   status      String
   resolutionDate  DateTime
 
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
   deletedAt  DateTime?
+
   isDeleted  Boolean   @default(false)
 
   carId            BigInt

--- a/src/controllers/contract-document.controller.ts
+++ b/src/controllers/contract-document.controller.ts
@@ -1,0 +1,44 @@
+import { Request, Response } from 'express';
+import {
+  downloadContractDocument,
+  getContractDocumentDraftList,
+  getContractDocumentList,
+  uploadContractDocument,
+} from '../services/contract-document.service';
+import { UnauthorizedError } from '../types/error.type';
+
+export const handleGetContractDocumentList = async (req: Request, res: Response) => {
+  const user = req.user;
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+  await getContractDocumentList(BigInt(user.id), req.body);
+  res.status(200).json({});
+};
+
+export const handleGetContractDocumentDraftList = async (req: Request, res: Response) => {
+  const user = req.user;
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+  await getContractDocumentDraftList();
+  res.status(200).json({});
+};
+
+export const handleUploadContractDocument = async (req: Request, res: Response) => {
+  const user = req.user;
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+  await uploadContractDocument();
+  res.status(200).json({ contractDocumentId: 1 });
+};
+
+export const handleDownloadContractDocument = async (req: Request, res: Response) => {
+  const user = req.user;
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+  await downloadContractDocument();
+  res.status(200).json({ message: '계약서 다운로드 성공' });
+};

--- a/src/repositories/contract-document.repository.ts
+++ b/src/repositories/contract-document.repository.ts
@@ -1,0 +1,64 @@
+import { GetContractListRequest } from '../types/contract-document.type';
+import { prisma } from '../utils/prisma.util';
+
+// 계약 목록 조희
+export const getContractListWithDocument = async (body: GetContractListRequest, _companyId: bigint) => {
+  const { page, pageSize, searchBy, keyword } = body;
+
+  const skip = (page - 1) * pageSize;
+
+  const where =
+    keyword && searchBy
+      ? {
+          [searchBy]: {
+            contains: keyword,
+            mode: 'insensitive',
+          },
+        }
+      : {};
+
+  const totalItemCount = await prisma.contract.count({
+    where: where,
+  });
+
+  const contractList = await prisma.contract.findMany({
+    where: where,
+    skip,
+    take: pageSize,
+    include: {
+      documents: {
+        select: {
+          id: true,
+          fileName: true,
+        },
+      },
+      car: {
+        select: {
+          carNumber: true,
+        },
+      },
+    },
+    orderBy: {
+      resolutionDate: 'desc',
+    },
+  });
+
+  const data = contractList.map((contract) => ({
+    id: contract.id,
+    contractName: contract.contractName,
+    resolutionDate: contract.resolutionDate,
+    documentsCount: contract.documents.length,
+    manager: contract.userId,
+    carNumber: contract.carId,
+    documents: contract.documents,
+  }));
+
+  const totalPages = Math.ceil(totalItemCount / pageSize);
+
+  return {
+    currentPage: page,
+    totalPages,
+    totalItemCount,
+    data,
+  };
+};

--- a/src/routes/contract-document.router.ts
+++ b/src/routes/contract-document.router.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import {
+  handleGetContractDocumentList,
+  handleGetContractDocumentDraftList,
+  handleUploadContractDocument,
+  handleDownloadContractDocument,
+} from '../controllers/contract-document.controller';
+
+const contractDocument = express.Router();
+
+// 계약서 업로드 시 계약 목록 조회
+contractDocument.get('/', handleGetContractDocumentList);
+// 계약서 추가 시 계약 목록 조회
+contractDocument.get('/draft', handleGetContractDocumentDraftList);
+// 계약서 업로드
+contractDocument.post('/upload', handleUploadContractDocument);
+// 계약서 다운로드
+contractDocument.get('/:id/download', handleDownloadContractDocument);
+
+export default contractDocument;

--- a/src/services/contract-document.service.ts
+++ b/src/services/contract-document.service.ts
@@ -1,0 +1,13 @@
+import { getContractListWithDocument } from '../repositories/contract-document.repository';
+import { GetContractListRequest } from '../types/contract-document.type';
+
+export const getContractDocumentList = async (_userId: bigint, body: GetContractListRequest) => {
+  const companyId: bigint = BigInt(1); // getCompanyByUserId
+  return await getContractListWithDocument(body, companyId);
+};
+
+export const getContractDocumentDraftList = async () => {};
+
+export const uploadContractDocument = async () => {};
+
+export const downloadContractDocument = async () => {};

--- a/src/types/contract-document.type.ts
+++ b/src/types/contract-document.type.ts
@@ -1,0 +1,6 @@
+export type GetContractListRequest = {
+  page: number; // 페이지 번호
+  pageSize: number; // 페이지 당 아이템 수
+  searchBy: string; // 검색 기준
+  keyword: string; // 검색어
+};


### PR DESCRIPTION
feat: 계약서 껍데기 코드 추가. 로직은 아직임

## 📝 요구사항
기본 코드 작성

- contract-document.router.ts
- contract-document.controller.ts
- contract-document.service.ts
- contract-document.repository.ts

## ✨ 변경사항
각각의 껍데기 코드만 들어가있습니다.
기능은 차후 개별적으로 이슈 만들어서 진행할 예정입니다.

- `contract` 모델에 `contractName` 이 추가 되었습니다.
   - 계약서 목록 을 받아올 때 필요해서 넣었지만, contract.contractName 이 약간 이상하긴 하네요.
   - 근데 API 명세서에 저리 되어있음.

## 🔍 변경 이유
- 작업용 껍데기 코드 작업

## ✅ 테스트 항목 (선택)

## 🚨 주의 사항

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #74

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
