### PR TITLE
feat: 대시보드 기능 API 구현

### DIFF
--- a/prisma/models/car.prisma.part
+++ b/prisma/models/car.prisma.part
@@ -5,16 +5,17 @@ model Car {
   carNumber           String    @unique @map("car_number")
   manufacturer        String
   model               String
+  type                String
   
   manufacturingYear   Int       @map("manufacturing_year")
   mileage             BigInt
   price               BigInt
+  totalPrice          BigInt?
   accidentCount       Int       @map("accident_count")
 
   explanation         String?
   accidentDetails     String?   @map("accident_details")
   status              String
-
   imageUrl            String?   @map("image_url")
   
   createdAt           DateTime  @default(now())

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import imagesRouter from './routes/images.router';
 import carRouter from './routes/car.router';
 import customerRouter from './routes/customer.router';
 import companiesRouter from './routes/company.router';
+import dashboardRouter from './routes/dashboard.router';
 
 import { notFoundHandler } from './handlers/not-found.handler';
 import { globalErrorHandler } from './handlers/global-error.handler';
@@ -23,6 +24,7 @@ app.use('/images', imagesRouter);
 app.use('/cars', carRouter);
 app.use('/customers', customerRouter);
 app.use('/companies', companiesRouter);
+app.use('/dashboard', dashboardRouter);
 
 // POST MIDDLEWARES
 app.use(notFoundHandler);

--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+import { DashboardResponse } from "../types/dashboard.type";
+import * as dashboardService from '../services/dashboard.service';
+
+/**
+ * @description 대시보드 데이터 조회
+ */
+export const getDashboard = async (_req: Request, res: Response) => {
+  // 현재 날짜
+  const currentMonth = new Date();
+  // 현재 월의 시작일과 마지막일 계산
+  const startOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
+  const endOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
+  // 지난 월의 시작일과 마지막일 계산
+  const startOfLastMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1);
+  const endOfLastMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 0);
+
+  const response: DashboardResponse = await dashboardService.getDashboard({
+    startOfMonth,
+    endOfMonth,
+    startOfLastMonth,
+    endOfLastMonth
+  });
+
+  res.status(200).json(response);
+}

--- a/src/repositories/car.repository.ts
+++ b/src/repositories/car.repository.ts
@@ -21,6 +21,7 @@ export const create = (data: CarCreateRequest & { companyId: bigint }) => {
   return prisma.car.create({
     data: {
       ...data,
+      type: data.type,
       status: 'possession',
       companyId: BigInt(data.companyId),
     },
@@ -48,6 +49,7 @@ export const createMany = async (cars: CarCsvUploadRequest[], companyId: bigint)
   const prepared = cars.map((car) => ({
     ...car,
     status: 'possession',
+    type: car.type,
     companyId, // 임시 값 (나중에 동적으로 처리 가능)
   }));
 

--- a/src/repositories/dashboard.repository.ts
+++ b/src/repositories/dashboard.repository.ts
@@ -1,0 +1,91 @@
+import { prisma } from '../utils/prisma.util';
+
+// 이번달 매출
+export const monthlySales = async(startOfMonth:Date, endOfMonth:Date) => {
+  return await prisma.car.aggregate({
+      _sum: {
+        totalPrice: true,
+      },
+      where: {
+        contracts: {
+          some: {
+            resolutionDate: {
+              gte: startOfMonth,
+              lte: endOfMonth,
+            },
+          },
+        },
+      },
+    })
+}
+
+// 지난달 매출
+export const lastMonthSales = async(startOfLastMonth:Date, endOfLastMonth:Date) => {
+  return await prisma.car.aggregate({
+      _sum: {
+        totalPrice: true,
+      },
+      where: {
+        contracts: {
+          some: {
+            resolutionDate: {
+              gte: startOfLastMonth,
+              lte: endOfLastMonth,
+            },
+          },
+        },
+      },
+    })
+}
+
+// 진행 중인 계약 건수
+export const proceedingContractsCount = async() => {
+  return await prisma.contract.count({
+    where: {
+      status: 'contractDraft'
+    },
+  });
+}
+
+// 완료된 계약 건수
+export const completedContractsCount = async() => {
+  return await prisma.contract.count({
+    where: {
+      status: 'contractSuccessful',
+    },
+  });
+}
+
+// 차량별 계약서 건수
+export const contractsByCarType = async() => {
+  return await prisma.car.groupBy({
+    by: ['type'],
+    _count: {
+      id: true, // 계약서 건수
+    },
+    where: {
+      contracts: {
+        some: {
+          status: 'contractSuccessful',
+        },
+      },
+    },
+  });
+}
+
+// 차량별 매출액
+export const salesByCarType = async() => {
+  return await prisma.car.groupBy({
+    by: ['type'],
+    _sum: {
+      totalPrice: true,
+    },
+    where: {
+      contracts: {
+        some: {
+          status: 'contractSuccessful',
+        },
+      },
+    },
+  });
+} 

--- a/src/routes/dashboard.router.ts
+++ b/src/routes/dashboard.router.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { getDashboard } from '../controllers/dashboard.controller';
+
+const router = express.Router();
+
+// 대시보드 데이터 조회
+router.route('/').get(getDashboard);
+
+export default router;

--- a/src/services/dashboard.service.ts
+++ b/src/services/dashboard.service.ts
@@ -1,0 +1,68 @@
+import { DashboardDateRange, DashboardResponse } from "../types/dashboard.type";
+import * as dashboardRepository from '../repositories/dashboard.repository';
+
+/**
+ * @description 대시보드 데이터 조회
+ */
+
+export const getDashboard = async ({
+  startOfMonth,
+  endOfMonth,
+  startOfLastMonth,
+  endOfLastMonth
+}: DashboardDateRange
+) => {
+  const [
+    monthlySales,
+    lastMonthSales,
+    proceedingContractsCount,
+    completedContractsCount,
+    contractsByCarType,
+    totalPriceByCarType
+  ] = await Promise.all([
+    dashboardRepository.monthlySales(startOfMonth, endOfMonth),
+    dashboardRepository.lastMonthSales(startOfLastMonth, endOfLastMonth),
+    dashboardRepository.proceedingContractsCount(),
+    dashboardRepository.completedContractsCount(),
+    dashboardRepository.contractsByCarType(),
+    dashboardRepository.salesByCarType()
+  ]);
+  // 이번달 매출
+  // 차량별 계약서 건수 포맷팅
+  const formattedContractsByCarType = contractsByCarType.map(car => ({
+    carType: car.type,
+    count: car._count.id ?? 0, // BigInt로 처리
+  }));
+  // 차량별 매출액 포맷팅
+  const formattedTotalPriceByCarType = totalPriceByCarType.map(car => ({
+    carType: car.type,
+    sales: Number(car._sum.totalPrice) ?? 0n, // BigInt로 처리
+  }));
+
+  // 지난달 매출
+  const lastMonthSalesValue = lastMonthSales._sum.totalPrice ?? 0n;
+  // 이번달 매출
+  const currentMonthSalesValue = monthlySales._sum.totalPrice ?? 0n;
+  // 성장률 계산
+  const growthRate = calculateGrowthRate(Number(currentMonthSalesValue), Number(lastMonthSalesValue));
+
+  const formattedDashboard: DashboardResponse = {
+    monthlySales: Number(monthlySales._sum.totalPrice) ?? null,
+    lastMonthSales: Number(lastMonthSales._sum.totalPrice) ?? null,
+    growthRate: growthRate,
+    proceedingContractsCount: proceedingContractsCount || 0,
+    completedContractsCount: completedContractsCount || 0,
+    contractsByCarType: formattedContractsByCarType || [],
+    salesByCarType: formattedTotalPriceByCarType || []
+  };
+
+  return formattedDashboard;
+}
+
+/**
+ * 성장률 계산 함수
+ */
+const calculateGrowthRate = (currentSales: number, lastMonthSales: number): number => {
+  if (lastMonthSales === 0) return currentSales > 0 ? 100 : 0;
+  return Math.round(((currentSales - lastMonthSales) / lastMonthSales) * 100);
+};

--- a/src/types/car.type.ts
+++ b/src/types/car.type.ts
@@ -9,6 +9,7 @@ export type CarCreateRequest = {
   accidentCount: number;
   explanation?: string;
   accidentDetails?: string;
+  type: string;
 };
 
 // 차량 수정 요청 타입
@@ -42,4 +43,5 @@ export type CarCsvUploadRequest = {
   accidentCount: number;
   explanation?: string;
   accidentDetails?: string;
+  type: string; 
 };

--- a/src/types/contract.type.ts
+++ b/src/types/contract.type.ts
@@ -1,0 +1,9 @@
+/**
+ * 계약 상태
+ * carInspection : 차량 확인
+ * priceNegotiation : 가격 협의
+ * contractDraft : 계약서 작성 중
+ * contractSuccessful : 계약 성공
+ * contractFailed : 계약 실패
+ */
+export type ContractStatus = 'carInspection' | 'priceNegotiation' | 'contractDraft' | 'contractSuccessful' | 'contractFailed';

--- a/src/types/dashboard.type.ts
+++ b/src/types/dashboard.type.ts
@@ -1,0 +1,27 @@
+export type DashboardResponse = {
+  monthlySales: number | null, // 이번달 매출
+  lastMonthSales: number | null, // 지난달 매출
+  growthRate: number, // 성장률
+  proceedingContractsCount: number, // 진행 중인 계약 건수
+  completedContractsCount: number, // 완료된 계약 건수
+  contractsByCarType: ContractsByCarType[],
+  salesByCarType: SalesByCarType[]
+}
+
+export type ContractsByCarType = {
+  carType: string,
+  count: number
+}
+
+export type SalesByCarType = {
+  carType: string,
+  sales: number
+}
+
+// 대시보드 날짜 데이터 타입
+export type DashboardDateRange = {
+  startOfMonth: Date,
+  endOfMonth: Date,
+  startOfLastMonth: Date,
+  endOfLastMonth: Date
+}

--- a/src/utils/parse.util.ts
+++ b/src/utils/parse.util.ts
@@ -42,6 +42,7 @@ export const csvToCarList = (csv: any, companyId: bigint) => {
       accidentCount: parseInt(accidentStr, 10),
       explanation: row.explanation || undefined,
       accidentDetails: row.accidentDetails || undefined,
+      type: row.type || 'sedan', // 기본값 설정
     };
 
     return parsedCar;


### PR DESCRIPTION
## 📝 요구사항
- [x] 이 달의 매출, 진행 중인 계약 수, 성사된 계약 수 표시
- [x] 차량타입별 계약수, 차량타입별 매출액 표시

## ✨ 변경사항
- car 스키마 모델에 type(차량 타입) 필드 추가
- car 생성 타입 / csv 업로드 타입에 type 추가
- 대시보드 `controller` / `service` / `repository` 구현
- app.ts에 대시보드 router 추가 및 `/dashboard` 경로 설정
- 대시보드 관련 type 정의 및 파일 추가
- 계약서 상태 관련 type 정의 및 파일 추가

## 🔍 변경 이유
- 대시보드 기능 지원을 위한 API 개발

## ✅ 테스트 항목 (선택)
- [x] 통계에 필요한 mock date 시딩 작업 후 postman을 통한 데이터 조회 확인

## 🚨 주의 사항
- car 스키마 모델 수정으로 인한 DB 마이그레이션 필요

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #60

## ✅ 체크리스트 
- [ ] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [ ] 코드 리뷰를 위한 설명이 충분한가요?
- [ ] 관련 이슈를 링크했나요?
