### PR TITLE
feat: companyId 추가 및 토큰 검증 미들웨어 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.12.0",
+        "cookie-parser": "^1.4.7",
         "csv-parse": "^6.1.0",
         "csv-parser": "^3.2.0",
         "dotenv": "^17.0.0",
@@ -19,6 +20,7 @@
         "multer": "^2.0.2"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.9",
         "@types/csv-parse": "^1.1.12",
         "@types/dotenv": "^6.1.1",
         "@types/express": "^4.17.17",
@@ -538,6 +540,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/csv-parse": {
@@ -1110,6 +1122,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/jrkgus413/nb2-dearcarmate-team1#readme",
   "dependencies": {
     "@prisma/client": "^6.12.0",
+    "cookie-parser": "^1.4.7",
     "csv-parse": "^6.1.0",
     "csv-parser": "^3.2.0",
     "dotenv": "^17.0.0",
@@ -34,6 +35,7 @@
     "multer": "^2.0.2"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.9",
     "@types/csv-parse": "^1.1.12",
     "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.17",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import ENV from './utils/env.util';
 import express from 'express';
+import cookieParser from 'cookie-parser';
 
 import rootRouter from './routes/root.router';
 import imagesRouter from './routes/images.router';
@@ -16,6 +17,7 @@ const port: number = Number(ENV.PORT) || 3000;
 // PRE MIDDLEWARES
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
 
 // ROUTERS
 app.get('/', rootRouter);

--- a/src/controllers/customer.controller.ts
+++ b/src/controllers/customer.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import * as customerService from '../services/customer.service';
 import { UnauthorizedError } from '../types/error.type';
+import { getUser } from '../utils/user.util';
 // import { BadRequestError, NotFoundError } from '../types/error.type';
 
 //
@@ -34,7 +35,7 @@ const getCustomerById: RequestHandler = async (req, res, next) => {
 const createCustomer: RequestHandler = async (req, res, next) => {
   try {
     if (req.user == null) {
-      throw new UnauthorizedError('권한이 없습니다.')
+      throw new UnauthorizedError('권한이 없습니다.');
     }
 
     const userId = BigInt(req.user.id);
@@ -51,7 +52,7 @@ const createCustomer: RequestHandler = async (req, res, next) => {
 const updateCustomer: RequestHandler = async (req, res, next) => {
   try {
     if (req.user == null) {
-      throw new UnauthorizedError('권한이 없습니다.')
+      throw new UnauthorizedError('권한이 없습니다.');
     }
 
     const customerId = BigInt(req.params.customerId);
@@ -60,7 +61,7 @@ const updateCustomer: RequestHandler = async (req, res, next) => {
 
     const updatedCustomerObj = await customerService.updateCustomer(userId, customerId, data);
 
-    res.status(200).json(updatedCustomerObj)
+    res.status(200).json(updatedCustomerObj);
   } catch (err) {
     next(err);
   }
@@ -70,7 +71,7 @@ const updateCustomer: RequestHandler = async (req, res, next) => {
 const removeCustomer: RequestHandler = async (req, res, next) => {
   try {
     if (req.user == null) {
-      throw new UnauthorizedError('권한이 없습니다.')
+      throw new UnauthorizedError('권한이 없습니다.');
     }
 
     const customerId = BigInt(req.params.customerId);
@@ -80,21 +81,25 @@ const removeCustomer: RequestHandler = async (req, res, next) => {
 
     console.log(deletedCustomerObj);
 
-    res.status(200).json({ "message": "고객 삭제 성공" });
+    res.status(200).json({ message: '고객 삭제 성공' });
   } catch (err) {
     next(err);
   }
 };
 
 const handleUploadCustomerCsvFile = async (req: Request, res: Response) => {
-  const user = req.user;
-  if (!user) {
-    throw new UnauthorizedError();
-  }
+  const user = getUser(req);
 
-  await customerService.uploadCustomerCsvFile(req.csv, BigInt(user.id));
+  await customerService.uploadCustomerCsvFile(user, req.csv);
 
   res.status(200).json({ message: '성공적으로 등록되었습니다.' });
 };
 
-export { getCustomersList, getCustomerById, createCustomer, updateCustomer, removeCustomer, handleUploadCustomerCsvFile };
+export {
+  getCustomersList,
+  getCustomerById,
+  createCustomer,
+  updateCustomer,
+  removeCustomer,
+  handleUploadCustomerCsvFile,
+};

--- a/src/enums/user.enum.ts
+++ b/src/enums/user.enum.ts
@@ -1,0 +1,6 @@
+export enum USER_ROLE {
+  NONE = 'none',
+  PUBLIC = 'public',
+  USER = 'user',
+  ADMIN = 'admin',
+}

--- a/src/middlewares/allow.middleware.ts
+++ b/src/middlewares/allow.middleware.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from 'express';
+import { ForbiddenError, UnauthorizedError } from '../types/error.type';
+import { setUser } from '../utils/user.util';
+import { USER_ROLE } from '../enums/user.enum';
+import { getAccessToken, verifyAccessToken } from '../utils/token.util';
+
+export const allow = (roles: USER_ROLE[]) => {
+  return async (req: Request, _res: Response, next: NextFunction) => {
+    // NONE
+    if (roles.includes(USER_ROLE.NONE)) {
+      return next();
+    }
+
+    const accessToken = getAccessToken(req);
+
+    // PUBLIC
+    // 토큰이 없어도 되는 API 에 사용합니다.
+    // 예: 회원가입
+    if (accessToken === undefined) {
+      if (roles.includes(USER_ROLE.PUBLIC)) {
+        return next();
+      }
+      throw new UnauthorizedError();
+    }
+
+    const payload = verifyAccessToken(accessToken);
+
+    setUser(req, payload);
+
+    const isAdmin = payload.isAdmin;
+
+    // USER
+    // 사용자만 사용하는 API 를 처리합니다.
+    // 관리자는 모든 기능을 사용할 수 있겠다 싶어서 || 로 처리했습니다.
+    if (roles.includes(USER_ROLE.USER) || isAdmin) {
+      return next();
+    }
+
+    // ADMIN
+    // 관리자만 사용할 수 있는 API 를 처리합니다.
+    if (roles.includes(USER_ROLE.ADMIN) && isAdmin) {
+      return next();
+    }
+
+    throw new ForbiddenError();
+  };
+};

--- a/src/routes/customer.router.ts
+++ b/src/routes/customer.router.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import * as customerController from '../controllers/customer.controller';
+import { allow } from '../middlewares/allow.middleware';
+import { USER_ROLE } from '../enums/user.enum';
 
 const customerRouter = Router();
 
@@ -18,6 +20,7 @@ customerRouter.patch('/:customerId', customerController.updateCustomer);
 // 고객 삭제
 customerRouter.delete('/:customerId', customerController.removeCustomer);
 
-customerRouter.post('/upload', customerController.handleUploadCustomerCsvFile);
+// 고객 대용량 업로드
+customerRouter.post('/upload', allow([USER_ROLE.USER]), customerController.handleUploadCustomerCsvFile);
 
 export default customerRouter;

--- a/src/routes/images.router.ts
+++ b/src/routes/images.router.ts
@@ -1,9 +1,11 @@
 import express from 'express';
 import { handleUploadImage } from '../controllers/images.controller';
 import { imageUploader } from '../utils/uploader';
+import { allow } from '../middlewares/allow.middleware';
+import { USER_ROLE } from '../enums/user.enum';
 
 const images = express.Router();
 
-images.post('/upload', imageUploader.single('image'), handleUploadImage);
+images.post('/upload', allow([USER_ROLE.USER]), imageUploader.single('image'), handleUploadImage);
 
 export default images;

--- a/src/services/customer.service.ts
+++ b/src/services/customer.service.ts
@@ -1,5 +1,6 @@
 import * as customerRepo from '../repositories/customer.repository';
 import { CustomerCsvUploadRequest, CustomerCreateData } from '../types/customer.type';
+import { Payload } from '../types/payload.type';
 import { csvToCustomerList } from '../utils/parse.util';
 
 // 고객 목록 조회
@@ -8,7 +9,7 @@ const getCustomersList = async (reqQuery: Record<string, string>) => {
   const pageSize = reqQuery.pageSize !== undefined ? Number(reqQuery.pageSize) : 10;
 
   // 1, 2, 3, ...
-  const page = reqQuery.page !== undefined ? Number(reqQuery.page) : 1
+  const page = reqQuery.page !== undefined ? Number(reqQuery.page) : 1;
 
   // name | email
   const searchBy = reqQuery.name;
@@ -48,7 +49,7 @@ const createCustomer = async (userId: bigint, data: CustomerCreateData) => {
 
   const createdCustomer = await customerRepo.create({
     companyId,
-    ...data
+    ...data,
   });
 
   return createdCustomer;
@@ -60,20 +61,16 @@ const updateCustomer = async (userId: bigint, customerId: bigint, data: Customer
 
   const user = await customerRepo.findUserCompanyId(userId);
   const companyId = user.companyId;
-  const updatedCustomer = await customerRepo.update(
-    customerId,
-    {
-      companyId,
-      ...data
-    }
-  );
+  const updatedCustomer = await customerRepo.update(customerId, {
+    companyId,
+    ...data,
+  });
 
   return updatedCustomer;
 };
 
 // 고객 삭제
 const removeCustomer = async (userId: bigint, customerId: bigint) => {
-
   // user가 진짜로 있는지 확인하는 용도
   await customerRepo.findUserCompanyId(userId);
 
@@ -82,8 +79,8 @@ const removeCustomer = async (userId: bigint, customerId: bigint) => {
   return deletedCustomer;
 };
 
-const uploadCustomerCsvFile = async (csv: any, _userId: bigint) => {
-  const companyId: bigint = BigInt(1); // getCompanyByUserId
+const uploadCustomerCsvFile = async (user: Payload, csv: any) => {
+  const companyId: bigint = BigInt(user.companyId); // getCompanyByUserId
   const customerList: CustomerCsvUploadRequest[] = csvToCustomerList(csv, companyId);
 
   return await customerRepo.createMany(customerList);

--- a/src/types/error.type.ts
+++ b/src/types/error.type.ts
@@ -14,7 +14,7 @@ export class BadRequestError extends HttpError {
 }
 
 export class UnauthorizedError extends HttpError {
-  constructor(message = 'Unauthorized') {
+  constructor(message = '로그인이 필요합니다.') {
     super(401, message);
   }
 }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -11,6 +11,7 @@ declare global {
   namespace Express {
     interface User {
       id: string;
+      companyId: string;
       isAdmin: boolean;
     }
 

--- a/src/types/payload.type.ts
+++ b/src/types/payload.type.ts
@@ -2,5 +2,6 @@ import { JwtPayload } from 'jsonwebtoken';
 
 export type Payload = JwtPayload & {
   id: string;
+  companyId: string;
   isAdmin: boolean;
 };

--- a/src/utils/user.util.ts
+++ b/src/utils/user.util.ts
@@ -1,0 +1,14 @@
+import { Request } from 'express';
+import { Payload } from '../types/payload.type';
+import { USER_ROLE } from '../enums/user.enum';
+import { UnauthorizedError } from '../types/error.type';
+
+export const getUser = (req: Request): Payload => {
+  const user = req.user;
+  if (user !== undefined) {
+    return user;
+  }
+  throw new UnauthorizedError();
+};
+export const setUser = (req: Request, user: Payload): Payload => (req.user = user);
+export const isUserAdmin = (user: Payload): boolean => user.role === USER_ROLE.ADMIN;


### PR DESCRIPTION
feat: companyId 추가 및 토큰 검증 미들웨어 추가

## 📝 요구사항
### `req.user` 에 `companyId` 를 추가합니다.
company 에 종속된 API 들이 많아서, 해당 `companyId` 를 같이 던져 줌으로써 반복된 코드를 줄이는데 목표가 있습니다.

## ✨ 변경사항
### `req.user` 에 `companyId` 가 추가되었습니다.
```typescript
declare global {
  namespace Express {
    interface User {
      id: string;
      companyId: string;
      isAdmin: boolean;
    }

    interface Request {
      user?: User;
    }
  }
}
```
### `user.util.ts` 추가
`req.user` 가 있는지 확인하는 코드가 많기에 유틸리티 함수로 빼냈습니다.

### 임시 검증 미들웨어 `allow.middleware.ts` 추가
토큰을 검증하고 req.user 에 로그인 한 유저의 정보를 담는 임시 미들웨어가 추가되었습니다.

사용하는 예시는 아래와 같습니다.

**customer.router.ts**
```typescript
customerRouter.post('/upload', allow([USER_ROLE.USER]), customerController.handleUploadCustomerCsvFile);
```

**customer.controller.ts**
```typescript
const user = getUser(req);
```

**images.router.ts**
```typescript
images.post('/upload', allow([USER_ROLE.USER]), imageUploader.single('image'), handleUploadImage);
```

간단하게 허용할 권한을 지정해주면 내부에서 해당 API 접근 권한에 따라서 에러를 반환하거나 user 를 req 에 담습니다.

## 🔍 변경 이유
- `companyId` 를 사용하는 API 가 많기 때문에 추가
- `req.user` 가 있는지 확인 하는 코드가 반복되어서 범용적인 유틸리티로 처리
- 로그인 기능은 없지만 `bearer {token}`으로 왔을 때 토큰을 검증하고 user 로 바꾸는 임시 미들웨어 추가

## ✅ 테스트 항목 (선택)
미들웨어 추가 후, 토큰 없이 요청이 있다면 아래와 같이 로그인이 필요하다는 에러가 표시됩니다.
<img width="1477" height="658" alt="스크린샷 2025-07-31 오후 4 12 46" src="https://github.com/user-attachments/assets/0b2c7c56-3e9c-403b-9481-fe1380916572" />

## 🚨 주의 사항
- 미들웨어 추가 후 개발 도중에는 NONE 으로 작업하거나, 임시 토큰을 만들어서 작업하시면 됩니다.

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #79

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
