### PR TITLE
feat: 계약서 추가 시 목록 조회 기능 구현

### DIFF
--- a/prisma/models/company.prisma.part
+++ b/prisma/models/company.prisma.part
@@ -11,6 +11,7 @@ model Company {
   customers Customer[]
   users     User[]
   cars      Car[]
+  contract  Contract[]
 
   @@map("companies")
 }

--- a/prisma/models/contract.prisma.part
+++ b/prisma/models/contract.prisma.part
@@ -14,13 +14,16 @@ model Contract {
   carId            BigInt
   customerId       BigInt    
   userId           BigInt    
-  // meetingId        BigInt
+  companyId        BigInt
+  // meetingId     BigInt
 
   car     Car      @relation(fields: [carId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   customer  Customer  @relation(fields: [customerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   user    User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+  company    Company    @relation(fields: [companyId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   meetings   Meeting[] // @relation(fields: [meetingId], references: [id])
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import carRouter from './routes/car.router';
 import customerRouter from './routes/customer.router';
 import companiesRouter from './routes/company.router';
 import dashboardRouter from './routes/dashboard.router';
+import contractDocumentRouter from './routes/contract-document.router';
 
 import { notFoundHandler } from './handlers/not-found.handler';
 import { globalErrorHandler } from './handlers/global-error.handler';
@@ -27,6 +28,7 @@ app.use('/cars', carRouter);
 app.use('/customers', customerRouter);
 app.use('/companies', companiesRouter);
 app.use('/dashboard', dashboardRouter);
+app.use('/contractDocuments', contractDocumentRouter);
 
 // POST MIDDLEWARES
 app.use(notFoundHandler);

--- a/src/controllers/contract-document.controller.ts
+++ b/src/controllers/contract-document.controller.ts
@@ -5,40 +5,34 @@ import {
   getContractDocumentList,
   uploadContractDocument,
 } from '../services/contract-document.service';
-import { UnauthorizedError } from '../types/error.type';
+import { getUser } from '../utils/user.util';
 
 export const handleGetContractDocumentList = async (req: Request, res: Response) => {
-  const user = req.user;
-  if (!user) {
-    throw new UnauthorizedError();
-  }
-  await getContractDocumentList(BigInt(user.id), req.body);
-  res.status(200).json({});
+  const user = getUser(req);
+
+  const body = await getContractDocumentList(BigInt(user.companyId), req.query);
+
+  res.status(200).json(body);
 };
 
 export const handleGetContractDocumentDraftList = async (req: Request, res: Response) => {
-  const user = req.user;
-  if (!user) {
-    throw new UnauthorizedError();
-  }
-  await getContractDocumentDraftList();
-  res.status(200).json({});
+  const user = getUser(req);
+
+  const body = await getContractDocumentDraftList(BigInt(user.companyId));
+
+  res.status(200).json(body);
 };
 
-export const handleUploadContractDocument = async (req: Request, res: Response) => {
-  const user = req.user;
-  if (!user) {
-    throw new UnauthorizedError();
-  }
+export const handleUploadContractDocument = async (_req: Request, res: Response) => {
+  //const user = getUser(req);
+
   await uploadContractDocument();
   res.status(200).json({ contractDocumentId: 1 });
 };
 
-export const handleDownloadContractDocument = async (req: Request, res: Response) => {
-  const user = req.user;
-  if (!user) {
-    throw new UnauthorizedError();
-  }
+export const handleDownloadContractDocument = async (_req: Request, res: Response) => {
+  //const user = getUser(req);
+
   await downloadContractDocument();
   res.status(200).json({ message: '계약서 다운로드 성공' });
 };

--- a/src/routes/contract-document.router.ts
+++ b/src/routes/contract-document.router.ts
@@ -5,16 +5,18 @@ import {
   handleUploadContractDocument,
   handleDownloadContractDocument,
 } from '../controllers/contract-document.controller';
+import { allow } from '../middlewares/allow.middleware';
+import { USER_ROLE } from '../enums/user.enum';
 
 const contractDocument = express.Router();
 
 // 계약서 업로드 시 계약 목록 조회
-contractDocument.get('/', handleGetContractDocumentList);
+contractDocument.get('/', allow([USER_ROLE.USER]), handleGetContractDocumentList);
 // 계약서 추가 시 계약 목록 조회
-contractDocument.get('/draft', handleGetContractDocumentDraftList);
+contractDocument.get('/draft', allow([USER_ROLE.USER]), handleGetContractDocumentDraftList);
 // 계약서 업로드
-contractDocument.post('/upload', handleUploadContractDocument);
+contractDocument.post('/upload', allow([USER_ROLE.USER]), handleUploadContractDocument);
 // 계약서 다운로드
-contractDocument.get('/:id/download', handleDownloadContractDocument);
+contractDocument.get('/:id/download', allow([USER_ROLE.USER]), handleDownloadContractDocument);
 
 export default contractDocument;

--- a/src/services/contract-document.service.ts
+++ b/src/services/contract-document.service.ts
@@ -1,12 +1,23 @@
-import { getContractListWithDocument } from '../repositories/contract-document.repository';
+import { getContractList, getContractListWithDocument } from '../repositories/contract-document.repository';
 import { GetContractListRequest } from '../types/contract-document.type';
+import { ParsedQs } from 'qs';
 
-export const getContractDocumentList = async (_userId: bigint, body: GetContractListRequest) => {
-  const companyId: bigint = BigInt(1); // getCompanyByUserId
-  return await getContractListWithDocument(body, companyId);
+export const getContractDocumentList = async (companyId: bigint, query: ParsedQs) => {
+  const { page = '1', pageSize = '10', searchBy = '', keyword = '' } = query;
+
+  const data: GetContractListRequest = {
+    page: parseInt(page as string, 10),
+    pageSize: parseInt(pageSize as string, 10),
+    searchBy: searchBy as string,
+    keyword: keyword as string,
+  };
+
+  return await getContractListWithDocument(data, companyId);
 };
 
-export const getContractDocumentDraftList = async () => {};
+export const getContractDocumentDraftList = async (companyId: bigint) => {
+  return await getContractList(companyId);
+};
 
 export const uploadContractDocument = async () => {};
 

--- a/src/utils/token.util.ts
+++ b/src/utils/token.util.ts
@@ -34,13 +34,31 @@ export const verifyRefreshToken = (token: string): Payload => {
 // ACCESS_TOKEN GET/SET/DELETE
 export const setAccessToken = (res: Response, token: string, options: CookieOptions) =>
   res.cookie(COOKIE_TYPE.ACCESS, token, options);
-export const getAccessToken = (req: Request) => req.cookies[COOKIE_TYPE.ACCESS];
+export const getAccessToken = (req: Request) => {
+  // 쿠키에 있는 토큰
+  const tokenFromCookie = req.cookies?.[COOKIE_TYPE.ACCESS];
+
+  // Authorization 헤더
+  const authHeader = req.headers.authorization;
+  const tokenFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : undefined;
+
+  return tokenFromCookie || tokenFromHeader;
+};
 export const deleteAccessToken = (res: Response) => res.clearCookie(COOKIE_TYPE.ACCESS);
 
 // REFRESH_TOKEN GET/SET/DELETE
 export const setRefreshToken = (res: Response, token: string, options: CookieOptions) =>
   res.cookie(COOKIE_TYPE.REFRESH, token, options);
-export const getRefreshToken = (req: Request) => req.cookies[COOKIE_TYPE.REFRESH];
+export const getRefreshToken = (req: Request) => {
+  // 쿠키에 있는 토큰
+  const tokenFromCookie = req.cookies?.[COOKIE_TYPE.REFRESH];
+
+  // Authorization 헤더
+  const authHeader = req.headers.authorization;
+  const tokenFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : undefined;
+
+  return tokenFromCookie || tokenFromHeader;
+};
 export const deleteRefreshToken = (res: Response) => res.clearCookie(COOKIE_TYPE.REFRESH);
 
 // 남은 토큰 기간 확인


### PR DESCRIPTION
feat: 계약서 추가 시 목록 조회 기능 구현

## 📝 요구사항
- 계약서 추가 시 목록 조회 기능 구현

## ✨ 변경사항
- `contract.prisma.part` 에 `company` 와의 관계성이 추가되었습니다.
- `company.prima.part` 에 `contract` 에 대한 관계성이 추가되었습니다.
- `contractDocuments/draft` 의 기능이 추가되었습니다.

## 🔍 변경 이유
- API 명세서 구현

## ✅ 테스트 항목 (선택)
**contractDocuments/**
<img width="1470" height="839" alt="스크린샷 2025-07-31 오후 9 47 19" src="https://github.com/user-attachments/assets/e18cc05a-cd87-4d2f-846c-4f471ba7401f" />
**contractDocuments/draft**
<img width="1525" height="837" alt="스크린샷 2025-07-31 오후 9 46 48" src="https://github.com/user-attachments/assets/f96725e6-3923-4827-bf2f-955aa38529f2" />


## 🚨 주의 사항
- `npm run prisma:migrate` 필요

## 🔗 관련 이슈 (선택)
- 관련 이슈: #88

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
