### PR TITLE
계약서 업로드 기능 구현

### DIFF
--- a/src/controllers/contract-document.controller.ts
+++ b/src/controllers/contract-document.controller.ts
@@ -6,6 +6,7 @@ import {
   uploadContractDocument,
 } from '../services/contract-document.service';
 import { getUser } from '../utils/user.util';
+import { getFile } from '../utils/file.util';
 
 export const handleGetContractDocumentList = async (req: Request, res: Response) => {
   const user = getUser(req);
@@ -23,11 +24,12 @@ export const handleGetContractDocumentDraftList = async (req: Request, res: Resp
   res.status(200).json(body);
 };
 
-export const handleUploadContractDocument = async (_req: Request, res: Response) => {
+export const handleUploadContractDocument = async (req: Request, res: Response) => {
+  const file = getFile(req);
   //const user = getUser(req);
 
-  await uploadContractDocument();
-  res.status(200).json({ contractDocumentId: 1 });
+  const body = await uploadContractDocument(file);
+  res.status(200).json(body);
 };
 
 export const handleDownloadContractDocument = async (_req: Request, res: Response) => {

--- a/src/controllers/images.controller.ts
+++ b/src/controllers/images.controller.ts
@@ -1,12 +1,9 @@
 import { RequestHandler } from 'express';
 import { uploadImage } from '../services/images.service';
-import { BadRequestError } from '../types/error.type';
+import { getFile } from '../utils/file.util';
 
 export const handleUploadImage: RequestHandler = async (req, res) => {
-  const file = req.file;
-  if (!file) {
-    throw new BadRequestError('파일이 없습니다.');
-  }
+  const file = getFile(req);
 
   const body = await uploadImage(file);
 

--- a/src/repositories/contract-document.repository.ts
+++ b/src/repositories/contract-document.repository.ts
@@ -1,4 +1,5 @@
 import { GetContractListRequest } from '../types/contract-document.type';
+import { FileCreateRequest } from '../types/file.type';
 import { prisma } from '../utils/prisma.util';
 
 // 계약 목록 조희
@@ -93,4 +94,10 @@ export const getContractList = async (companyId: bigint) => {
     id: contract.id,
     data: `${contract.car.model} - ${contract.customer.name} 고객님`,
   }));
+};
+
+export const createContractDocument = async (fileCreateRequest: FileCreateRequest) => {
+  const createdContractDocument = await prisma.file.create({ data: fileCreateRequest });
+
+  return createdContractDocument;
 };

--- a/src/routes/contract-document.router.ts
+++ b/src/routes/contract-document.router.ts
@@ -7,6 +7,7 @@ import {
 } from '../controllers/contract-document.controller';
 import { allow } from '../middlewares/allow.middleware';
 import { USER_ROLE } from '../enums/user.enum';
+import { fileUploader } from '../utils/uploader';
 
 const contractDocument = express.Router();
 
@@ -15,7 +16,12 @@ contractDocument.get('/', allow([USER_ROLE.USER]), handleGetContractDocumentList
 // 계약서 추가 시 계약 목록 조회
 contractDocument.get('/draft', allow([USER_ROLE.USER]), handleGetContractDocumentDraftList);
 // 계약서 업로드
-contractDocument.post('/upload', allow([USER_ROLE.USER]), handleUploadContractDocument);
+contractDocument.post(
+  '/upload',
+  allow([USER_ROLE.PUBLIC]),
+  fileUploader.single('contractDocument'),
+  handleUploadContractDocument
+);
 // 계약서 다운로드
 contractDocument.get('/:id/download', allow([USER_ROLE.USER]), handleDownloadContractDocument);
 

--- a/src/services/contract-document.service.ts
+++ b/src/services/contract-document.service.ts
@@ -1,6 +1,12 @@
-import { getContractList, getContractListWithDocument } from '../repositories/contract-document.repository';
+import {
+  createContractDocument,
+  getContractList,
+  getContractListWithDocument,
+} from '../repositories/contract-document.repository';
 import { GetContractListRequest } from '../types/contract-document.type';
 import { ParsedQs } from 'qs';
+import { bucket } from '../utils/firebase';
+import { FileCreateRequest } from '../types/file.type';
 
 export const getContractDocumentList = async (companyId: bigint, query: ParsedQs) => {
   const { page = '1', pageSize = '10', searchBy = '', keyword = '' } = query;
@@ -19,6 +25,46 @@ export const getContractDocumentDraftList = async (companyId: bigint) => {
   return await getContractList(companyId);
 };
 
-export const uploadContractDocument = async () => {};
+export const uploadContractDocument = async (file: Express.Multer.File) => {
+  return new Promise(async (resolve, reject) => {
+    const fileName = `contractDocuments/${Date.now()}_${file.originalname}`;
+    const blob = bucket.file(fileName);
+
+    const blobStream = blob.createWriteStream({
+      metadata: {
+        contentType: file.mimetype,
+      },
+    });
+
+    blobStream.on('error', (error) => {
+      console.error('[contractDocuments] blob stream error: ', error);
+      reject(error);
+    });
+
+    blobStream.on('finish', async () => {
+      try {
+        await blob.makePublic();
+        const url = `https://storage.googleapis.com/${bucket.name}/${blob.name}`;
+
+        const name = file.originalname;
+        const ext = file.originalname.split('.').pop() || '';
+        const size = BigInt(file.size);
+        const fileCreateRequest: FileCreateRequest = {
+          url,
+          name,
+          ext,
+          size,
+        };
+
+        const createdContractDocument = await createContractDocument(fileCreateRequest);
+        resolve({ contractDocumentId: Number(createdContractDocument.id) });
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    blobStream.end(file.buffer);
+  });
+};
 
 export const downloadContractDocument = async () => {};

--- a/src/services/images.service.ts
+++ b/src/services/images.service.ts
@@ -35,8 +35,8 @@ export const uploadImage = async (file: Express.Multer.File) => {
 
         const createdImage = await createUserImage(fileCreateRequest);
         resolve({ imageUrl: createdImage.url });
-      } catch (err) {
-        reject(err);
+      } catch (error) {
+        reject(error);
       }
     });
 

--- a/src/utils/file.util.ts
+++ b/src/utils/file.util.ts
@@ -1,0 +1,10 @@
+import { Request } from 'express';
+import { UnauthorizedError } from '../types/error.type';
+
+export const getFile = (req: Request): Express.Multer.File => {
+  const file = req.file;
+  if (file !== undefined) {
+    return file;
+  }
+  throw new UnauthorizedError();
+};


### PR DESCRIPTION
계약서 업로드 기능 구현

## 📝 요구사항
계약서 업로드 기능 구현

## ✨ 변경사항
### 계약서 업로드 기능이 추가되었습니다.
놀랍게도 `계약서 업로드` 는 정말로 파일을 업로드 하고 고유 id 만 받아오는 기능만 구현됩니다.
실제로 프론트에서 [계약서 수정] 버튼을 누르면 `PATCH contract/:id` 가 호출됩니다.

## 🔍 변경 이유
- 기능 구현

## ✅ 테스트 항목 (선택)
**테스트 결과**
<img width="1485" height="654" alt="스크린샷 2025-08-01 오전 11 39 49" src="https://github.com/user-attachments/assets/ebab56fa-c8d6-4f58-a328-b49a94fb03d7" />


## 🚨 주의 사항


## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #98

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
