### PR TITLE
feat: 대시보드 데이터 조회 최적화 및 트랜잭션 처리 추가

### DIFF
--- a/src/services/dashboard.service.ts
+++ b/src/services/dashboard.service.ts
@@ -5,36 +5,28 @@ import * as dashboardRepository from '../repositories/dashboard.repository';
  * @description 대시보드 데이터 조회
  */
 
-export const getDashboard = async ({
-  startOfMonth,
-  endOfMonth,
-  startOfLastMonth,
-  endOfLastMonth
-}: DashboardDateRange
-) => {
-  const [
+export const getDashboard = async ({ startOfMonth, endOfMonth, startOfLastMonth, endOfLastMonth }: DashboardDateRange) => {
+  const {
     monthlySales,
     lastMonthSales,
     proceedingContractsCount,
     completedContractsCount,
     contractsByCarType,
-    totalPriceByCarType
-  ] = await Promise.all([
-    dashboardRepository.monthlySales(startOfMonth, endOfMonth),
-    dashboardRepository.lastMonthSales(startOfLastMonth, endOfLastMonth),
-    dashboardRepository.proceedingContractsCount(),
-    dashboardRepository.completedContractsCount(),
-    dashboardRepository.contractsByCarType(),
-    dashboardRepository.salesByCarType()
-  ]);
-  // 이번달 매출
+    salesByCarType
+  } = await dashboardRepository.getDashboard({
+    startOfMonth,
+    endOfMonth,
+    startOfLastMonth,
+    endOfLastMonth
+  });
+
   // 차량별 계약서 건수 포맷팅
   const formattedContractsByCarType = contractsByCarType.map(car => ({
     carType: car.type,
     count: car._count.id ?? 0, // BigInt로 처리
   }));
   // 차량별 매출액 포맷팅
-  const formattedTotalPriceByCarType = totalPriceByCarType.map(car => ({
+  const formattedTotalPriceByCarType = salesByCarType.map(car => ({
     carType: car.type,
     sales: Number(car._sum.totalPrice) ?? 0n, // BigInt로 처리
   }));

--- a/src/types/dashboard.type.ts
+++ b/src/types/dashboard.type.ts
@@ -1,3 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
 export type DashboardResponse = {
   monthlySales: number | null, // 이번달 매출
   lastMonthSales: number | null, // 지난달 매출
@@ -25,3 +27,5 @@ export type DashboardDateRange = {
   startOfLastMonth: Date,
   endOfLastMonth: Date
 }
+
+export type TransactionClient = Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;


### PR DESCRIPTION
## 📝 요구사항
- 데이터베이스 최적화를 위한 대시보드 API 트랜잭션 적용

## ✨ 변경사항
- service에서 promise.all([통계함수]) 방식 -> repository 각 통계 함수 트랜잭션 처리
- dashboard.type에 트랜잭션 타입 추가

## 🔍 변경 이유
- 트랜잭션을 활용해 데이터의 무결성을 보장(심화 요구사항)

## ✅ 테스트 항목 (선택)
- mock data 삽입 후 대시보드 api 호출
- 트랜잭션 작업 전
<img width="1663" height="1325" alt="image" src="https://github.com/user-attachments/assets/07d1fcba-e7d8-4225-a81e-4197fd1f101f" />
- 트랜잭션 작업 후
<img width="1201" height="901" alt="image" src="https://github.com/user-attachments/assets/5268cb07-2ad5-49c9-9170-f712223c8816" />

## 🚨 주의 사항
- 대시보드 이외에 작업 영향도 없음

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #107 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
