### PR TITLE
refactor: service 계층 코드 분배

### DIFF
--- a/src/controllers/customer.controller.ts
+++ b/src/controllers/customer.controller.ts
@@ -4,7 +4,7 @@ import { getUser } from '../utils/user.util';
 import { BadRequestError } from '../types/error.type';
 
 // 고객 목록 조회
-const getCustomersList = async (
+export const getCustomersList = async (
   req: Request<{}, {}, {}, Record<string, string>>,
   res: Response,
   next: NextFunction
@@ -13,6 +13,7 @@ const getCustomersList = async (
 
     const user = getUser(req);
 
+    // undefined, null => error
     const companyId = BigInt(user.companyId);
 
     const query = req.query;
@@ -23,33 +24,47 @@ const getCustomersList = async (
     // 1, 2, 3, ...
     const page = query.page !== undefined ? Number(query.page) : 1;
 
+    const string400 = "잘못된 요청입니다.";
+
+    if(pageSize < 1 || Object.is(pageSize, NaN)){
+      throw new BadRequestError(string400); // 올바른 페이지 크기가 아닙니다.
+    } else if(page < 1 || Object.is(page, NaN)){
+      throw new BadRequestError(string400);
+    } // 올바른 페이지 번호가 아닙니다.
+
+    const take = pageSize;
+    const skip = (page - 1) * pageSize;
+
     // name | email
     const searchBy = query.searchBy;
     // 문자열의 일부분. 예: 박 -> 박지호, 박기수, 김박준
     const keyword = query.keyword;
     if(searchBy && !['name', 'email'].includes(searchBy)){
-      throw new BadRequestError("검색 기준이 올바르지 않습니다.");
+      throw new BadRequestError(string400);// 검색 기준이 올바르지 않습니다.
     } else if(keyword && typeof keyword !== 'string'){
-      throw new BadRequestError("검색은 문자열만 가능합니다.");
+      throw new BadRequestError(string400);// 검색은 문자열만 가능합니다.
     }
-
-    const take = pageSize;
-    const skip = (page - 1) * pageSize;
 
     const customersListObj = await customerService.getCustomersList({companyId, take, skip, searchBy, keyword});
 
-    res.status(200).json(customersListObj);
+    res.status(200).json({
+      currentPage: page,
+      pageSize,
+      totalPages:Math.ceil(customersListObj.totalItemCount / pageSize),
+      ...customersListObj
+    });
   } catch (err) {
     next(err);
   }
 };
 
 // 고객 상세 정보 조회
-const getCustomerById: RequestHandler = async (req, res, next) => {
+export const getCustomerById: RequestHandler = async (req, res, next) => {
   try {
 
     getUser(req);
 
+    // undefined, null => error
     const customerId = BigInt(req.params.customerId);
     const customerObj = await customerService.getCustomerById(customerId);
 
@@ -60,15 +75,15 @@ const getCustomerById: RequestHandler = async (req, res, next) => {
 };
 
 // 고객 등록
-const createCustomer: RequestHandler = async (req, res, next) => {
+export const createCustomer: RequestHandler = async (req, res, next) => {
   try {
 
     const user = getUser(req);
 
     const companyId = BigInt(user.companyId);
-    const data = req.body;
+    const data = {companyId, ...req.body};
 
-    const createdCustomerObj = await customerService.createCustomer({ companyId, ...data });
+    const createdCustomerObj = await customerService.createCustomer(data);
 
     res.status(201).json(createdCustomerObj);
   } catch (err) {
@@ -77,7 +92,7 @@ const createCustomer: RequestHandler = async (req, res, next) => {
 };
 
 // 고객 수정
-const updateCustomer: RequestHandler = async (req, res, next) => {
+export const updateCustomer: RequestHandler = async (req, res, next) => {
   try {
 
     const user = getUser(req);
@@ -85,9 +100,9 @@ const updateCustomer: RequestHandler = async (req, res, next) => {
     const companyId = BigInt(user.companyId);
     const customerId = BigInt(req.params.customerId);
 
-    const data = req.body;
+    const data = {companyId, ...req.body};
 
-    const updatedCustomerObj = await customerService.updateCustomer(customerId, { companyId, ...data });
+    const updatedCustomerObj = await customerService.updateCustomer(customerId, data);
 
     res.status(200).json(updatedCustomerObj);
   } catch (err) {
@@ -96,7 +111,7 @@ const updateCustomer: RequestHandler = async (req, res, next) => {
 };
 
 // 고객 삭제
-const removeCustomer: RequestHandler = async (req, res, next) => {
+export const removeCustomer: RequestHandler = async (req, res, next) => {
   try {
 
     getUser(req);
@@ -112,12 +127,10 @@ const removeCustomer: RequestHandler = async (req, res, next) => {
 };
 
 // 고객 대용량 업로드
-const handleUploadCustomerCsvFile = async (req: Request, res: Response) => {
+export const handleUploadCustomerCsvFile = async (req: Request, res: Response) => {
   const user = getUser(req);
 
   await customerService.uploadCustomerCsvFile(user, req.csv);
 
   res.status(200).json({ message: '성공적으로 등록되었습니다.' });
 };
-
-export { getCustomersList, getCustomerById, createCustomer, updateCustomer, removeCustomer, handleUploadCustomerCsvFile };

--- a/src/repositories/customer.repository.ts
+++ b/src/repositories/customer.repository.ts
@@ -1,45 +1,78 @@
-import { Prisma } from "@prisma/client";
 import { prisma } from '../utils/prisma.util';
-import { CustomerCsvUploadRequest, FindManyArgs } from '../types/customer.type';
+import { CountArgs, CustomerCreateData, CustomerCsvUploadRequest, CustomerUpdateData, FindManyArgs, QueryMode } from '../types/customer.type';
 
 // 고객 목록 조회
-const findAll = async ({ companyId, take, skip, searchBy, keyword }: FindManyArgs) => await prisma.customer.findMany({
-    where: {
-        companyId,
-        ...(typeof searchBy === 'string' && keyword !== undefined && {
-            [searchBy]: {
-                contains: keyword,
-                mode: Prisma.QueryMode.insensitive
-            }
-        }),
-    },
+export const findAll = async ({ companyId, take, skip, searchBy, keyword }: FindManyArgs) => await prisma.customer.findMany({
+  where: {
+    companyId,
+    ...(typeof searchBy === 'string' && keyword !== undefined && {
+      [searchBy]: {
+        contains: keyword,
+        mode: QueryMode.insensitive
+      }
+    }),
+  },
 
-    take,
-    skip,
+  take,
+  skip,
 
-    include: {
-        _count: {
-            select: {
-                contracts: true
-            }
-        }
+  include: {
+    _count: {
+      select: {
+        contracts: true
+      }
     }
+  }
 });
 
 // 고객 상세 정보 조회
-const findById = async (query: Prisma.CustomerFindUniqueOrThrowArgs) => await prisma.customer.findUniqueOrThrow(query);
+export const findById = async (customerId: bigint) => await prisma.customer.findUniqueOrThrow({
+  where: { id: customerId },
+
+  include: {
+    _count: {
+      select: {
+        contracts: true
+      }
+    }
+  }
+});
 
 // 고객 등록
-const create = async (query: Prisma.CustomerCreateArgs) => await prisma.customer.create(query);
+export const create = async (data: CustomerCreateData) => await prisma.customer.create({data});
 
 // 고객 수정
-const update = async (query: Prisma.CustomerUpdateArgs) => await prisma.customer.update(query);
+export const update = async (customerId: bigint, data: CustomerUpdateData) => await prisma.customer.update({
+  where:{ id:customerId },
+  data,
+  include:{
+    _count:{
+      select:{
+        contracts: true
+      }
+    }
+  }
+});
 
 // 고객 삭제
-const remove = async (query: Prisma.CustomerDeleteArgs) => await prisma.customer.delete(query);
+export const remove = async (customerId: bigint) => await prisma.customer.delete({where: {id: customerId}});
+
+export const count = async({ companyId, searchBy, keyword }: CountArgs) => {
+  const allCustomersCount = await prisma.customer.count({
+    where: {
+      companyId,
+      ...(typeof searchBy === 'string' && keyword !== undefined && {
+        [searchBy]: {
+          contains: keyword,
+          mode: QueryMode.insensitive
+        }
+      }),
+    }
+  });
+
+  return allCustomersCount;
+}
 
 // 고객 대용량 업로드
-const createMany = async (data: CustomerCsvUploadRequest[]) =>
-    await prisma.customer.createMany({ data, skipDuplicates: true });
-
-export { findAll, findById, create, update, remove, createMany };
+export const createMany = async (data: CustomerCsvUploadRequest[]) =>
+  await prisma.customer.createMany({ data, skipDuplicates: true });

--- a/src/services/customer.service.ts
+++ b/src/services/customer.service.ts
@@ -1,99 +1,70 @@
-import { Prisma } from '@prisma/client';
 import * as customerRepo from '../repositories/customer.repository';
-import { CustomerCsvUploadRequest, CustomerCreateData, FindManyArgs } from '../types/customer.type';
+import { CustomerCsvUploadRequest, CustomerCreateData, FindManyArgs, CustomerUpdateData } from '../types/customer.type';
 import { Payload } from '../types/payload.type';
 import { csvToCustomerList } from '../utils/parse.util';
-import { convertBigIntToString } from '../utils/convert.util';
 
 // 고객 목록 조회
-const getCustomersList = async (
+export const getCustomersList = async (
   {companyId, take, skip, searchBy, keyword}: FindManyArgs
 ) => {
 
   const findCustomersList = await customerRepo.findAll({companyId, take, skip, searchBy, keyword});
 
-  return convertBigIntToString(findCustomersList.map((customer) => ({...customer, contractCount: customer._count.contracts, _count: undefined })));
+  const totalItemCount = await customerRepo.count({companyId, searchBy, keyword}); 
+
+  return {
+    totalItemCount,
+    data: findCustomersList.map((customer) => ({...customer, contractCount: customer._count.contracts, _count: undefined }))
+  };
 };
 
 // 고객 상세 정보 조회
-const getCustomerById = async (customerId: bigint) => {
+export const getCustomerById = async (customerId: bigint) => {
 
-  const ormQuery: Prisma.CustomerFindUniqueOrThrowArgs = {
-    where: {id:customerId},
+  const findCustomer = await customerRepo.findById(customerId);
 
-    include:{
-      _count:{
-        select:{
-          contracts: true
-        }
-      }
-    }
-  }
-
-  const findCustomer = await customerRepo.findById(ormQuery);
-
-  return findCustomer;
+  return {
+    ...findCustomer,
+    contractCount: findCustomer._count.contracts,
+    _count: undefined
+  };
 };
 
 // 고객 등록
-const createCustomer = async (
-  data: CustomerCreateData
-) => {
+export const createCustomer = async (data: CustomerCreateData) => {
 
-  const ormQuery:Prisma.CustomerCreateArgs = {
-    data,
-    include: {
-      _count:{
-        select:{
-          contracts: true
-        }
-      }
-    }
+  const createdCustomer = await customerRepo.create(data);
+
+  return {
+    ...createdCustomer,
+    contractCount: 0
   };
-
-  const createdCustomer = await customerRepo.create(ormQuery);
-
-  return createdCustomer;
 };
 
 // 고객 수정
-const updateCustomer = async (customerId: bigint, data: CustomerCreateData) => {
+export const updateCustomer = async (customerId: bigint, data: CustomerUpdateData) => {
 
-  const ormQuery: Prisma.CustomerUpdateArgs = {
-    where:{ id:customerId },
-    data,
-    include:{
-      _count:{
-        select:{
-          contracts: true
-        }
-      }
-    }
+  const updatedCustomer = await customerRepo.update(customerId, data);
+
+  return {
+    ...updatedCustomer,
+    contractCount: updatedCustomer._count.contracts,
+    _count: undefined
   };
-
-  const updatedCustomer = await customerRepo.update(ormQuery);
-
-  return updatedCustomer;
 };
 
 // 고객 삭제
-const removeCustomer = async (customerId: bigint) => {
+export const removeCustomer = async (customerId: bigint) => {
 
-  const ormQuery: Prisma.CustomerDeleteArgs = {
-    where: {id: customerId}
-  };
-
-  const deletedCustomer = await customerRepo.remove(ormQuery);
+  const deletedCustomer = await customerRepo.remove(customerId);
 
   return deletedCustomer;
 };
 
 // 고객 대용량 업로드
-const uploadCustomerCsvFile = async (user: Payload, csv: any) => {
+export const uploadCustomerCsvFile = async (user: Payload, csv: any) => {
   const companyId: bigint = BigInt(user.companyId);
   const customerListRequest: CustomerCsvUploadRequest[] = csvToCustomerList(csv, companyId);
 
   return await customerRepo.createMany(customerListRequest);
 };
-
-export { getCustomersList, getCustomerById, createCustomer, updateCustomer, removeCustomer, uploadCustomerCsvFile };

--- a/src/types/customer.type.ts
+++ b/src/types/customer.type.ts
@@ -54,3 +54,12 @@ export type FindManyArgs = {
   searchBy?: string;
   keyword?: string;
 };
+
+export type CountArgs = Omit<FindManyArgs, 'take' | 'skip'>;
+
+export const QueryMode = {
+  default: 'default',
+  insensitive: 'insensitive'
+};
+
+export type QueryMode = (typeof QueryMode)[keyof typeof QueryMode]


### PR DESCRIPTION
## 📝 요구사항
서비스 계층에 controller, repository에 포함되어야 할 내용을 분배한다.

## ✨ 변경사항
- export 문을 const 옆에 붙인다.
- service 코드에 넣기 전에 검증 할 수 있는 내용들을 옮긴다.
- ormQuery를 repository에 옮긴다.
- return 타입을 맞추었다.

## 🔍 변경 이유
- 타입이 복잡해지지 않고 더 간결해진다.
- 계층 아키텍처를 잘 준수할 수 있다.

## ✅ 테스트 항목 (선택)

## 🚨 주의 사항

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #119 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
