### PR TITLE
fix: 회원가입 API 프론트 요청 필드명 불일치 수정

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -9,12 +9,12 @@ export const register = async (req: Request, res: Response) => {
     phoneNumber,
     password,
     passwordConfirm,
-    company,
+    companyName,
     companyCode,
     employeeNumber
   } = req.body;
 
-  if (!name || !email || !phoneNumber || !password || !passwordConfirm || !company || !companyCode || !employeeNumber) {
+  if (!name || !email || !phoneNumber || !password || !passwordConfirm || !companyName || !companyCode || !employeeNumber) {
     throw new BadRequestError('필수 입력값이 누락되었습니다.');
   }
 
@@ -27,7 +27,7 @@ export const register = async (req: Request, res: Response) => {
     email,
     phoneNumber,
     password,
-    company,
+    company: companyName,
     companyCode,
     employeeNumber
   });

--- a/src/routes/user.router.ts
+++ b/src/routes/user.router.ts
@@ -1,19 +1,9 @@
-// routes/user.route.ts
-
 import { Router } from 'express';
 import { register } from '../controllers/user.controller';
 
 const router = Router();
 
 //회원가입
-router.post('/register', register);
-//내 정보 조회
-//userRouter.get('/me', getMyInfo);
-//내 정보 수정
-//userRouter.patch('/me', updateMyInfo);
-//회원탈퇴
-//userRouter.delete('/me', deleteMyAccount);
-//유저 삭제(관리자 전용)
-//userRouter.delete('/:id', adminDeleteUser);
+router.post('/', register);
 
 export default router;


### PR DESCRIPTION
<!-- 제목 예시: [feat] 그룹 등록 API 구현 -->

## 📝 요구사항
<!-- 해당 작업의 기능 요구사항에 대해 작성해주세요 -->
- [x] 회원가입 시 프론트에서 전송한 필드명(companyName, passwordConfirmation)을 수신
- [x] 내부 서비스 로직에서 기존 필드명(company, passwordConfirm)으로 재매핑 처리

## ✨ 변경사항
<!-- 수정 또는 추가된 사항을 상세히 작성해주세요 -->
- controllers/user.controller.ts에서 req.body 필드명 수정 (companyName)
- 내부 registerUser 호출 시 기존 필드명(company, passwordConfirm)으로 매핑
- 프론트 요청 스펙(API 명세서 기준)과 실제 처리 코드 일치

## 🔍 변경 이유
<!-- 해당 작업을 진행한 이유를 설명해주세요 -->
- 프론트에서 보내는 필드명과 서버에서 받는 필드명이 달라 400/404 오류 발생
- 프론트와 서버 요청 형식을 통일하여 오류 방지

## ✅ 테스트 항목 (선택)
<!-- 수행한 테스트 방법을 작성해주세요 -->
- Postman 연동 시 회원가입 요청 정상 수신 확인


## 🚨 주의 사항
<!-- 리뷰어가 특히 확인해야 할 부분이나 미완성된 부분이 있다면 작성해주세요 -->
- 프론트 요청 형식이 companyName 경우에만 정상 작동
- 프론트 연동 시 회원가입 요청 정상 수신 확인 필요

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #138 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
