### PR TITLE
fix: 회원가입 API 필드 이름 불일치 수정

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -8,17 +8,17 @@ export const register = async (req: Request, res: Response) => {
     email,
     phoneNumber,
     password,
-    passwordConfirm,
+    passwordConfirmation,
     companyName,
     companyCode,
     employeeNumber
   } = req.body;
 
-  if (!name || !email || !phoneNumber || !password || !passwordConfirm || !companyName || !companyCode || !employeeNumber) {
+  if (!name || !email || !phoneNumber || !password || !passwordConfirmation || !companyName || !companyCode || !employeeNumber) {
     throw new BadRequestError('필수 입력값이 누락되었습니다.');
   }
 
-  if (password !== passwordConfirm) {
+  if (password !== passwordConfirmation) {
     throw new BadRequestError('비밀번호와 비밀번호 확인이 일치하지 않습니다');
   }
 

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -6,7 +6,7 @@ export type userRegisterRequest = {
   phoneNumber: string;
   password: string;
   passwordConfirmation: string;
-  company: string;
+  companyName: string;
   companyCode: string;
 };
 


### PR DESCRIPTION
<!-- 제목 예시: [feat] 그룹 등록 API 구현 -->

## 📝 요구사항
<!-- 해당 작업의 기능 요구사항에 대해 작성해주세요 -->
- [x] 회원가입 시 비밀번호와 비밀번호 확인 입력
- [x] 프론트에서 전송하는 passwordConfirmation 필드 처리
- [x] Postman 테스트 시 비밀번호 일치 여부 검사

## ✨ 변경사항
<!-- 수정 또는 추가된 사항을 상세히 작성해주세요 -->
- user.controller.ts에서 req.body 구조분해 시 passwordConfirm → passwordConfirmation으로 수정
- 밀번호 일치 검사 구문 수정
- 프론트 요청 필드명과 백엔드 수신 필드명 일치시켜 정상 처리되도록 개선

## 🔍 변경 이유
<!-- 해당 작업을 진행한 이유를 설명해주세요 -->
- 프론트에서 passwordConfirmation으로 요청을 보내는데, 서버에서는 passwordConfirm으로 받고 있어 undefined 처리됨
- 필드명을 프론트 기준에 맞춰 수정함으로써 회원가입 정상 동작하게 수정

## ✅ 테스트 항목 (선택)
<!-- 수행한 테스트 방법을 작성해주세요 -->
- Postman 에서 POST /users 요청 시 passwordConfirmation 필드 포함 → 정상 회원가입 확인
- 비밀번호와 일치하지 않을 경우 에러 메시지 정상 출력 확인

## 🚨 주의 사항
<!-- 리뷰어가 특히 확인해야 할 부분이나 미완성된 부분이 있다면 작성해주세요 -->
- 이 변경은 컨트롤러 단에서 처리된 것으로, 서비스 및 DB에는 영향 없음

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #141 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
