### PR TITLE
[fix] Car API 전반에 대한 개선

### DIFF
--- a/src/controllers/car.controller.ts
+++ b/src/controllers/car.controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express';
 import * as carService from '../services/car.service';
 import { BadRequestError, NotFoundError, UnauthorizedError } from '../types/error.type';
+import { getUser } from '../utils/user.util';
+import { prisma } from '../utils/prisma.util';
 
 function convertBigIntToNumber(obj: any): any {
   if (Array.isArray(obj)) {
@@ -15,9 +17,38 @@ function convertBigIntToNumber(obj: any): any {
 }
 
 // 전체 차량 조회
-export const getAllCars = async (_req: Request, res: Response) => {
-  const cars = await carService.getAllCars();
-  res.status(200).json(convertBigIntToNumber(cars));
+export const getAllCars = async (req: Request, res: Response) => {
+  const user = await getUser(req); // req.user에서 추출
+  const page = parseInt(req.query.page as string) || 1;
+  const limit = parseInt(req.query.limit as string) || 10;
+  const skip = (page - 1) * limit;
+
+  const [cars, totalCount] = await Promise.all([
+    prisma.car.findMany({
+      where: {
+        isDeleted: false,
+        companyId: BigInt(user.companyId),
+      },
+      skip,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.car.count({
+      where: {
+        isDeleted: false,
+        companyId: BigInt(user.companyId),
+      },
+    }),
+  ]);
+
+  const totalPages = Math.ceil(totalCount / limit);
+
+  return res.status(200).json({
+    currentPage: page,
+    totalPages,
+    totalItemCount: totalCount,
+    data: cars,
+  });
 };
 
 // 차량 단건 조회
@@ -38,8 +69,8 @@ export const createCar = async (req: Request, res: Response) => {
     throw new BadRequestError('필수 값이 누락되었습니다.');
   }
 
-  if (!req.user) throw new UnauthorizedError();
-  const companyId = BigInt(req.user.companyId);
+  const user = await getUser(req); // ✅ 여기서 user 추출
+  const companyId = BigInt(user.companyId);
 
   const created = await carService.createCar(data, companyId);
   res.status(201).json(convertBigIntToNumber(created));
@@ -50,11 +81,21 @@ export const updateCar = async (req: Request, res: Response) => {
   const id = BigInt(req.params.carId);
   const data = req.body;
 
+  const user = await getUser(req);
+
   const existing = await carService.getCarById(id);
-  if (!existing) throw new NotFoundError('존재하지 않는 차량입니다');
+
+  if (!existing || existing.isDeleted) {
+    throw new NotFoundError('존재하지 않는 차량입니다');
+  }
+
+  // ✅ 본인 회사 차량인지 확인
+  if (BigInt(existing.companyId) !== BigInt(user.companyId)) {
+    throw new UnauthorizedError('해당 차량을 수정할 권한이 없습니다');
+  }
 
   const updated = await carService.updateCar(id, data);
-  res.status(201).json(convertBigIntToNumber(updated));
+  res.status(200).json(convertBigIntToNumber(updated));
 };
 
 // 차량 삭제

--- a/src/middlewares/allow.middleware.ts
+++ b/src/middlewares/allow.middleware.ts
@@ -26,7 +26,7 @@ export const allow = (roles: USER_ROLE[]) => {
     const payload = verifyAccessToken(accessToken);
 
     setUser(req, payload);
-
+    
     const isAdmin = payload.isAdmin;
 
     // USER

--- a/src/repositories/car.repository.ts
+++ b/src/repositories/car.repository.ts
@@ -44,6 +44,17 @@ export const softDelete = (id: bigint) => {
   });
 };
 
+// 차량번호 + 회사ID 기준으로 soft delete된 차량 찾기
+export const findDeletedByCarNumber = async (carNumber: string, companyId: bigint) => {
+  return await prisma.car.findFirst({
+    where: {
+      carNumber,
+      companyId,
+      isDeleted: true,
+    },
+  });
+};
+
 // 차량 대용량 업로드
 export const createMany = async (cars: CarCsvUploadRequest[], companyId: bigint) => {
   const prepared = cars.map((car) => ({

--- a/src/routes/car.router.ts
+++ b/src/routes/car.router.ts
@@ -1,11 +1,17 @@
 import { Router } from 'express';
 import * as carController from '../controllers/car.controller';
-import { csvUploader } from '../utils/uploader';
-import { csvToObject } from '../middlewares/csv-parser.middleware';
 import { allow } from '../middlewares/allow.middleware';
 import { USER_ROLE } from '../enums/user.enum';
+import { csvUploader } from '../utils/uploader';
+import { csvToObject } from '../middlewares/csv-parser.middleware';
 
 const router = Router();
+
+// 사용자 인증 미들웨어 적용
+router.use(allow([USER_ROLE.USER, USER_ROLE.ADMIN]));
+
+// 차량 모델 목록 조회
+router.get('/models', carController.getCarModels);
 
 // 차량 목록 조회
 router.get('/', carController.getAllCars);
@@ -24,8 +30,5 @@ router.delete('/:carId', carController.deleteCar);
 
 // 차량 대용량 업로드
 router.post('/upload', allow([USER_ROLE.USER]), csvUploader.single('file'), csvToObject, carController.uploadCars);
-
-// 차량 모델 목록 조회
-router.get('/models', carController.getCarModels);
 
 export default router;

--- a/src/services/car.service.ts
+++ b/src/services/car.service.ts
@@ -15,7 +15,18 @@ export const getCarById = async (id: bigint) => {
 
 // 차량 등록
 export const createCar = async (data: CarCreateRequest, companyId: bigint) => {
-  const dataWithCompanyId = { ...data, companyId };
+  const deletedCar = await carRepo.findDeletedByCarNumber(data.carNumber, companyId);
+
+  if (deletedCar) {
+    return await carRepo.update(deletedCar.id, {
+      ...data,
+      isDeleted: false,
+      deletedAt: null,
+      status: 'possession', // 초기 상태로
+    });
+  }
+
+  const dataWithCompanyId = { ...data, companyId }; 
   return await carRepo.create(dataWithCompanyId);
 };
 

--- a/src/types/car.type.ts
+++ b/src/types/car.type.ts
@@ -10,6 +10,9 @@ export type CarCreateRequest = {
   explanation?: string;
   accidentDetails?: string;
   type: string;
+  status?: string;
+  isDeleted?: boolean;   
+  deletedAt?: Date | null; 
 };
 
 // 차량 수정 요청 타입


### PR DESCRIPTION
<!-- 제목 예시: [feat] 그룹 등록 API 구현 -->

## 📝 요구사항
<!-- 해당 작업의 기능 요구사항에 대해 작성해주세요 -->
- [x] 차량 목록 조회 시 응답 포맷 일치
- [x] soft delete된 차량 재등록 시 복구 처리
- [x] 차량 모델 목록 조회 가능
- [x] 인증 유저 정보 일관 처리 (getUser 사용)
- [x]  차량 API 라우터에 권한 미들웨어 적용

## ✨ 변경사항
<!-- 수정 또는 추가된 사항을 상세히 작성해주세요 -->
- createCar에서 soft delete된 차량이 존재할 경우 복구 처리 (isDeleted: false)
- getAllCars 응답을 { data, currentPage, totalPages } 형태로 리팩토링
- car.route.ts에서 /models 라우트 순서 수정 → /:carId보다 위로 이동
- 모든 req.user 접근 코드를 getUser(req)로 통일
- allow([USER_ROLE.USER, USER_ROLE.ADMIN]) 미들웨어 전체 라우트에 적용
- getCarModels 응답 누락 문제 수정 및 JSON 반환 보장

## 🔍 변경 이유
<!-- 해당 작업을 진행한 이유를 설명해주세요 -->
- 기존 차량 API 응답이 명세와 달라 프론트엔드 연동 시 혼란 발생
- soft delete된 차량 등록 시 unique constraint 에러 발생 → 복구 방식으로 개선
- /cars/models 라우트가 carId로 인식되어 404 또는 500 오류 발생
- 사용자 인증 흐름이 통일되지 않아 추후 유지보수에 위험 요소 존재

## ✅ 테스트 항목 (선택)
<!-- 수행한 테스트 방법을 작성해주세요 -->
- Postman으로 GET /cars/models, GET /cars, POST /cars 등 요청 테스트
- soft delete → 재등록 → 복구 여부 확인
- 인증 없는 요청 → 401 발생 확인
- 정상 토큰으로 요청 시 데이터 접근 가능 확인

## 🚨 주의 사항
<!-- 리뷰어가 특히 확인해야 할 부분이나 미완성된 부분이 있다면 작성해주세요 -->
- 기존 soft delete된 차량이 있는 경우, 복구가 아닌 중복 생성되던 동작이 변경됨
- Postman 테스트 시 반드시 Authorization 헤더 포함 필요

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #152 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
