### PR TITLE
fix: 회원가입 API 라우트 경로를 /users로 수정

### DIFF
--- a/src/routes/user.router.ts
+++ b/src/routes/user.router.ts
@@ -6,7 +6,7 @@ import { USER_ROLE } from '../enums/user.enum';
 const router = Router();
 
 //회원가입
-router.post('/register', UserController.register);
+router.post('/', UserController.register);
 //내 정보 조회
 router.get('/me', allow([USER_ROLE.USER]), UserController.getMyInfo);
 

--- a/src/types/car.type.ts
+++ b/src/types/car.type.ts
@@ -1,8 +1,32 @@
+export const MANUFACTURERS = [
+  '현대', '기아', 'BMW', '벤츠', '쉐보레',
+  '아우디', '폭스바겐', '도요타', '테슬라', '르노', '볼보', '지프',
+] as const;
+
+export type Manufacturer = (typeof MANUFACTURERS)[number];
+
+export const CAR_MODELS: Record<Manufacturer, string[]> = {
+  현대: ['아반떼', '쏘나타', '그랜저', '투싼', '베뉴', '싼타페', '팰리세이드', '아이오닉5', '아이오닉6'],
+  기아: ['K3', 'K5', 'K7', 'K9', 'K8', '스포티지', '쏘렌토토', '셀토스', 'EV6'],
+  BMW: ['320i', '520d', 'X5'],
+  벤츠: ['E클래스', 'S클래스', 'GLC'],
+  쉐보레: ['스파크', '말리부', '트랙스'],
+  아우디: ['A3', 'A4', 'A6', 'A8', 'Q3', 'Q5', 'Q7', 'Q8', 'e-tron'],
+  폭스바겐: ['골프', '파사트', '티구안', '투아렉', 'ID.4', 'ID.3'],
+  도요타: ['프리우스', '캠리', '라브4'],
+  테슬라: ['모델3', '모델Y', '모델S'],
+  르노: ['클리오', '캡처', '조에', '마스터', '트위지'],
+  볼보: ['XC40', 'XC60', 'XC90'],
+  지프: ['랭글러', '체로키', '그랜드 체로키'],
+};
+
+export type Model = (typeof CAR_MODELS)[Manufacturer][number];
+
 // 차량 등록 요청 타입
 export type CarCreateRequest = {
   carNumber: string;
-  manufacturer: string;
-  model: string;
+  manufacturer: Manufacturer;
+  model: Model;
   manufacturingYear: number;
   mileage: number;
   price: number;


### PR DESCRIPTION
<!-- 제목 예시: [feat] 그룹 등록 API 구현 -->

## 📝 요구사항
<!-- 해당 작업의 기능 요구사항에 대해 작성해주세요 -->
- [x] 회원가입 시 프론트에서 POST /users로 요청하면 백엔드가 이를 처리해야 함

## ✨ 변경사항
<!-- 수정 또는 추가된 사항을 상세히 작성해주세요 -->
- user.route.ts에서 회원가입 라우트를 /register → /로 수정하여 POST /users 요청 처리 가능하도록 수정

## 🔍 변경 이유
<!-- 해당 작업을 진행한 이유를 설명해주세요 -->
- 프론트와 백엔드 라우트 불일치로 인해 회원가입 요청 시 404 에러가 발생함
- RESTful 경로 통일 및 프론트 연동을 위함

## ✅ 테스트 항목 (선택)
<!-- 수행한 테스트 방법을 작성해주세요 -->
- Postman으로 POST /users 요청 시 정상적으로 회원가입되는지 확인
- 프론트 연동 후 회원가입 동작 여부 확인

## 🚨 주의 사항
<!-- 리뷰어가 특히 확인해야 할 부분이나 미완성된 부분이 있다면 작성해주세요 -->
- 없음 (프론트 요청 경로에 맞춰 백엔드만 수정한 단순 라우트 변경)
- 
## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #161 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
