### PR TITLE
feat: 내 정보 수정 기능 구현 및 관련 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ generated/
 prisma/migrations/
 prisma/schema.prisma
 service-account-key.json
+
+docker-compose.yml 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from 'express';
 import { registerUser } from '../services/user.service';
-import { BadRequestError, NotFoundError } from '../types/error.type';
+import { BadRequestError } from '../types/error.type';
 import * as UserService from '../services/user.service'
 import { getUser } from '../utils/user.util';
-
+import { UserUpdateRequest } from '../types/user.type';
 
 export const register = async (req: Request, res: Response) => {
   const {
@@ -54,11 +54,25 @@ export const getMyInfo = async (req: Request, res: Response) => {
   const { id } = getUser(req);
   const userId = BigInt(id);
 
-  const userInfo = await UserService.getMyInfo(userId);
-  if (!userInfo) {
-    throw new NotFoundError('사용자 정보를 찾을 수 없습니다.');
-  }
+  const user = await UserService.getMyInfo(userId);
 
-  res.status(200).json(userInfo);
+  res.status(200).json(user);
 };
 
+// 내 정보 수정
+export const updateMyInfo = async (req: Request, res: Response) => {
+  const { id } = getUser(req);
+  const { employeeNumber, phoneNumber, currentPassword, password, passwordConfirmation, imageUrl }: UserUpdateRequest = req.body;
+  const userId = BigInt(id);
+
+  const user = await UserService.updateMyInfo(userId, {
+    employeeNumber,
+    phoneNumber,
+    currentPassword,
+    password,
+    passwordConfirmation,
+    imageUrl
+  });
+
+  res.status(200).json(user);
+};

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from 'express';
-import { getUser } from '../utils/user.util';
+import { registerUser } from '../services/user.service';
 import { BadRequestError, NotFoundError } from '../types/error.type';
-import * as UserService from '../services/user.service';
-import { userRepository } from '../repositories/user.repository';
+import * as UserService from '../services/user.service'
+import { getUser } from '../utils/user.util';
+
 
 export const register = async (req: Request, res: Response) => {
   const {
@@ -24,7 +25,7 @@ export const register = async (req: Request, res: Response) => {
     throw new BadRequestError('비밀번호와 비밀번호 확인이 일치하지 않습니다');
   }
 
-  const user = await UserService.registerUser({
+  const user = await registerUser({
     name,
     email,
     phoneNumber,
@@ -37,18 +38,16 @@ export const register = async (req: Request, res: Response) => {
   res.status(201).json(user);
 };
 
+//회원 탈퇴 (soft delete)
+export const deleteMyAccount = async (req: Request, res: Response) => {
+  const { id } = getUser(req);
+  const userId = Number(id);
 
-// 회원 탈퇴 (soft delete)
-export const deleteMyAccount = async (userId: number): Promise<void> => {
-  // 1) (선택) 사용자 존재 여부 확인
-  const existingUser = await userRepository.getUserById(userId);
-  if (!existingUser) {
-    throw new NotFoundError('유저가 존재하지 않습니다.');
-  }
-
-  // 2) soft delete 처리
-  await userRepository.softDeleteUser(userId);
-};
+  await UserService.deleteMyAccount(userId);
+  return res
+    .status(200)
+    .json({ message: '정상적으로 회원 탈퇴되었습니다.' });
+}
 
 // 내 정보 조회
 export const getMyInfo = async (req: Request, res: Response) => {
@@ -62,3 +61,4 @@ export const getMyInfo = async (req: Request, res: Response) => {
 
   res.status(200).json(userInfo);
 };
+

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -52,7 +52,6 @@ export const userRepository = {
   getUserById: (userId: number) =>
     prisma.user.findUnique({ where: { id: userId } }),
 
-  // 여기 추가!
   softDeleteUser: (userId: number) =>
     prisma.user.update({
       where: { id: userId },

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,3 +1,4 @@
+import { UserUpdateRequest } from '../types/user.type';
 import { prisma } from '../utils/prisma.util';
 
 interface CreateUserParams {
@@ -63,16 +64,34 @@ export const userRepository = {
 };
 
 export const getMyInfo = async (userId: bigint) => {
-  return prisma.user.findUnique({
+  return await prisma.user.findUnique({
     where: { id: userId },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      phoneNumber: true,
-      company: true,
-      companyCode: true,
-      employeeNumber: true
+    include: {
+      affiliatedCompany: {
+        select: {
+          companyCode: true
+        }
+      }
     }
   });
 }
+
+export const updateMyInfo = async (userId: bigint, data: UserUpdateRequest) => {
+  return await prisma.user.update({
+    where: { id: userId },
+    data: {
+      employeeNumber: data.employeeNumber,
+      phoneNumber: data.phoneNumber,
+      password: data.password,
+      image_url: data.imageUrl
+    },
+    include: {
+      affiliatedCompany: {
+        select: {
+          companyCode: true
+        }
+      }
+    }
+  });
+}
+

--- a/src/routes/user.router.ts
+++ b/src/routes/user.router.ts
@@ -12,6 +12,8 @@ router.get('/me', allow([USER_ROLE.USER]), UserController.getMyInfo);
 
 //회원 탈퇴 
 router.delete('/me', allow([USER_ROLE.USER]), UserController.deleteMyAccount);
+// 내 정보 수정
+router.patch('/me', allow([USER_ROLE.USER]), UserController.updateMyInfo);
 
 export default router;
 

--- a/src/routes/user.router.ts
+++ b/src/routes/user.router.ts
@@ -10,4 +10,8 @@ router.post('/', UserController.register);
 //내 정보 조회
 router.get('/me', allow([USER_ROLE.USER]), UserController.getMyInfo);
 
+//회원 탈퇴 
+router.delete('/me', allow([USER_ROLE.USER]), UserController.deleteMyAccount);
+
 export default router;
+

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -66,7 +66,7 @@ export const registerUser = async (data: RegisterUserParams) => {
   };
 };
 
-//회원 탈퇴 서비스, 함수 만들기 
+//회원 탈퇴 
 const { userRepository } = UserRepository;
 
 export const deleteMyAccount = async (userId: number) => {

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,78 +1,23 @@
-// ✅ 회원가입 요청
-export type userRegisterRequest = {
+// 유저 수정 요청
+export type UserUpdateRequest = {
+	employeeNumber: string,
+	phoneNumber: string,
+	currentPassword: string,
+	password: string,
+	passwordConfirmation: string,
+	imageUrl: string
+}
+
+// 유저 응답
+export type UserResponse = {
+  id: bigint;
   name: string;
   email: string;
   employeeNumber: string;
   phoneNumber: string;
-  password: string;
-  passwordConfirmation: string;
-  companyName: string;
-  companyCode: string;
-};
-
-// ✅ 로그인 요청
-export type loginRequest = {
-  email: string;
-  password: string;
-};
-
-// ✅ 로그인 응답
-export type loginResponse = {
-  user: {
-    id: number;
-    name: string;
-    email: string;
-    employeeNumber: string;
-    phoneNumber: string;
-    imageUrl: string;
-    isAdmin: boolean;
-    company: {
-      companyCode: string;
-    };
-  };
-  accessToken: string;
-  refreshToken: string;
-};
-
-// ✅ 내 정보 조회 응답
-export type getMeResponse = {
-  id: number;
-  name: string;
-  email: string;
-  employeeNumber: string;
-  phoneNumber: string;
-  imageUrl: string;
+  image_url: string;
   isAdmin: boolean;
   company: {
     companyCode: string;
   };
-};
-
-// ✅ 내 정보 수정 요청
-export type updateMeRequest = {
-  employeeNumber: string;
-  phoneNumber: string;
-  currentPassword: string;
-  password: string;
-  passwordConfirmation: string;
-  imageUrl: string;
-};
-
-// ✅ 내 정보 수정 응답
-export type updateMeResponse = {
-  id: number;
-  name: string;
-  email: string;
-  employeeNumber: string;
-  phoneNumber: string;
-  imageUrl: string;
-  isAdmin: boolean;
-  company: {
-    companyCode: string;
-  };
-};
-
-// ✅ 회원 탈퇴 응답 / 유저 삭제 응답
-export type deleteUserResponse = {
-  message: string; // "유저 삭제 성공"
 };


### PR DESCRIPTION
## 📝 요구사항
- [x] 수정 시 비밀번호를 입력하여 2차 검증 진행
- [x] 이름, 이메일, 사원번호, 연락처가 조회됩니다.
- [x] 사원번호, 연락처, 비밀번호 수정이 가능합니다.

## ✨ 변경사항
- user.controller.ts / user.service.ts / user.repository.ts 사용자 수정 로직 추가
- 현재 비밀번호 검증 로직 추가
- 변경 비밀번호 매치 확인
- 사원번호 중복 검증 로직 추가
- user.router.ts patch /me 경로 추가

## 🔍 변경 이유
- 사용자 정보 수정 기능 지원

## ✅ 테스트 항목 (선택)
1. 사용자 이메일 / 비밀번호를 통해 로그인
2. 토큰을  header에 붙여넣기
3. 사용자 변경 정보와 현재 비밀번호를 body에 추가
4. 변경된 정보와 기존 정보 출력 확인

## 🚨 주의 사항
- 없음

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #115 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
