### PR TITLE
fix: 사원번호 중복 확인 로직 개선

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -120,7 +120,7 @@ export const updateMyInfo = async (userId: bigint, data: UserUpdateRequest) => {
   // 사원번호 중복 확인
   if (data.employeeNumber) {
     const existingUser = await UserRepository.findUserByEmployeeNumber(data.employeeNumber);
-    if (existingUser && existingUser.companyCode !== user.companyCode && existingUser.id !== userId) {
+    if (existingUser && existingUser.id !== userId) {
       throw new ConflictError('이미 존재하는 사원번호입니다.');
     }
   }


### PR DESCRIPTION
## 📝 요구사항
- [x] 사원번호는 고유 값으로 중복될 수 없음

## ✨ 변경사항
- 사원번호 검증 로직에서 회사 조건 제외

## 🔍 변경 이유
- 사원번호는 고유 값이라 회사가 다른 경우에도 중복 될 수 없어 prisma 에러 발생 확인

## ✅ 테스트 항목 (선택)
1. 로그인 진행
2. 개인정보 페이지 이동
3. 중복된 사원번호 수정
    - 회사가 동일한 경우 / 회사가 다른 경우 확인

## 🚨 주의 사항
- 없음

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #175 

## ✅ 체크리스트 
- [ ] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [ ] 코드 리뷰를 위한 설명이 충분한가요?
- [ ] 관련 이슈를 링크했나요?
