### PR TITLE
fix: 비밀번호 해싱 추가 및 사용자 정보 업데이트 로직 수정

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -124,8 +124,11 @@ export const updateMyInfo = async (userId: bigint, data: UserUpdateRequest) => {
       throw new ConflictError('이미 존재하는 사원번호입니다.');
     }
   }
-
-  const updatedUser = await UserRepository.updateMyInfo(userId, data);
+  const hashedPassword = await hash(data.password, 10);
+  const updatedUser = await UserRepository.updateMyInfo(userId, {
+    ...data,
+    password: hashedPassword,
+  });
 
   return {
     id: updatedUser.id,


### PR DESCRIPTION
## 📝 요구사항
- 비밀번호 저장 시 해싱 처리

## ✨ 변경사항
- 사용자 비밀번호 변경 시 해싱 처리 로직 추가

## 🔍 변경 이유
- 사용자 비밀번호는 개인 정보로 해싱 처리 필요

## ✅ 테스트 항목 (선택)
1. 로그인 진행
2. 개인정보 조회 화면
3. 비밀번호 변경
4. DB에 해싱된 값으로 변경 확인

## 🚨 주의 사항
- 사용자 정보 수정 후 DB 확인 필요

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #182 

## ✅ 체크리스트 
- [ ] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [ ] 코드 리뷰를 위한 설명이 충분한가요?
- [ ] 관련 이슈를 링크했나요?
