### PR TITLE
fix: 회사 정보 반환 형식 수정 및 중복 회사코드 처리 추가

### DIFF
--- a/src/services/company.service.ts
+++ b/src/services/company.service.ts
@@ -8,14 +8,15 @@ import * as CompanyRepository from '../repositories/company.repository';
  */
 export const createCompany = async ({ companyName, companyCode }: CompanyCreateRequest) => {
   const existingCompany = await CompanyRepository.getCompanyByCode(companyCode);
-  console.log(existingCompany);
+  
   if (existingCompany) throw new ConflictError(`동일한 회사코드가 이미 존재합니다.`);
 
   const newCompany = await CompanyRepository.createCompany({ companyName, companyCode });
   const { _count, ...companyWithoutUsers } = newCompany;
   const formattedCompany = {
     ...companyWithoutUsers,
-    usersCount: _count.users,
+    companyName: companyWithoutUsers.name,
+    userCount: _count.users,
   };
 
   return convertBigIntToString(formattedCompany);
@@ -29,7 +30,8 @@ export const getCompanies = async ({ whereCondition, pageSize, page }: CompanyLi
 
   const formattedCompanies = companies.map(({ _count, ...company }) => ({
     ...company,
-    usersCount: _count.users,
+    companyName: company.name,
+    userCount: _count.users,
   }));
 
   return {
@@ -53,7 +55,7 @@ export const getUserbyCompany = async ({ whereCondition, pageSize, page }: Compa
       email: user.email,
       employeeNumber: user.employeeNumber,
       phoneNumber: user.phoneNumber,
-      company: user.affiliatedCompany,
+      company: { companyName: user.affiliatedCompany.name }
     };
   });
 
@@ -82,7 +84,8 @@ export const updateCompanies = async (companyId: bigint, { companyName, companyC
   const { _count, ...companyWithoutUsers } = companies;
   const formattedCompany = {
     ...companyWithoutUsers,
-    usersCount: _count.users,
+    companyName: companyWithoutUsers.name,
+    userCount: _count.users,
   };
 
   return convertBigIntToString(formattedCompany);


### PR DESCRIPTION
## 📝 요구사항
- [ ] 회사 목록 조회 시 기업명, 기업코드, 소속 유저 수 출력
- [ ] 유저 목록 조회 시 기업명, 이름, 이메일, 사원번호, 연락처 출력

## ✨ 변경사항
- 회사 목록에서 회사명 응답 데이터 필드명을 `name` ->`companyNme`으로 수정
- 유저 목록에서 회사명 응답 데이터 필드명을 `name` ->`companyNme`으로 수정

## 🔍 변경 이유
- 프론트와 필드명이 상이하여 회사명이 출력되지 않음

## ✅ 테스트 항목 (선택)
1. 관리자 계정 로그인
2. 회사목록 / 유저목록 확인
3. 목록 테이블에서 회사명 정상 출력 확인

## 🚨 주의 사항
- 관리자 계정으로 로그인 필수

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #192 

## ✅ 체크리스트 
- [ ] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [ ] 코드 리뷰를 위한 설명이 충분한가요?
- [ ] 관련 이슈를 링크했나요?
