### PR TITLE
fix: 회사 삭제 시 소속 사용자 soft delete 처리 추가

### DIFF
--- a/src/repositories/company.repository.ts
+++ b/src/repositories/company.repository.ts
@@ -132,7 +132,7 @@ export const deleteCompanies = async (companyId: bigint) => {
   return await prisma.$transaction(async (tx) => {
     // 소속 사용자 삭제
     await tx.user.updateMany({
-      where: { companyId: companyId },
+      where: { companyId: companyId, isAdmin: false },
       data: {
         deletedAt: new Date(),
         isDeleted: true

--- a/src/repositories/company.repository.ts
+++ b/src/repositories/company.repository.ts
@@ -126,16 +126,28 @@ export const updateCompanies = async (companyId: bigint, { companyName, companyC
 
 /**
  * @description 회사 삭제
+ * * 회사와 연관된 사용자들은 soft delete 처리
  */
 export const deleteCompanies = async (companyId: bigint) => {
-  return await prisma.company.update({
-    data: {
-      deletedAt: new Date(),
-      isDeleted: true
-    },
-    where: { id: companyId },
-    select: {
-      id: true
-    }
-  })
-}
+  return await prisma.$transaction(async (tx) => {
+    // 소속 사용자 삭제
+    await tx.user.updateMany({
+      where: { companyId: companyId },
+      data: {
+        deletedAt: new Date(),
+        isDeleted: true
+      }
+    });
+    // 회사 삭제
+    await tx.company.update({
+      where: { id: companyId },
+      data: {
+        deletedAt: new Date(),
+        isDeleted: true
+      },
+      select: {
+        id: true
+      }
+    });
+  });
+} 


### PR DESCRIPTION
## 📝 요구사항  
- [x] 사용자는 회사에 소속되어 있음  
- [x] 회사 삭제 시 관련되어 있는 회사 소속 사용자도 삭제 처리되어야 함  

## ✨ 변경사항  
- 회사 삭제 시 해당 회사에 소속된 사용자들도 함께 soft delete 처리되도록 로직 추가  
- 회사 삭제 및 사용자 삭제를 하나의 트랜잭션으로 처리하여 데이터 무결성 보장  

## 🔍 변경 이유  
- 사용자는 특정 회사에 소속되어 있기 때문에, 회사가 삭제될 경우 해당 사용자들도 시스템 상에서 더 이상 유효하지 않음  
- 데이터 정합성을 위해 회사 삭제 시 관련 사용자도 함께 삭제 처리 필요  

## ✅ 테스트 항목  
- 회사 삭제 시 관련 사용자가 soft delete 되는지 확인

## 🚨 주의 사항  
- soft delete 방식으로 사용자 삭제 처리됨
- 
## 🔗 관련 이슈 (선택)  
- 관련 이슈: #195   

## ✅ 체크리스트  
- [x] 팀 내 컨벤션이 잘 지켜졌나요?  
- [x] 테스트를 모두 통과했나요?  
- [x] 코드 리뷰를 위한 설명이 충분한가요?  
- [x] 관련 이슈를 링크했나요?  
