### PR TITLE
fix: 로그인 soft delete 적용

### DIFF
--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -4,6 +4,8 @@ export const getUserByEmail = async (email: string) =>
   await prisma.user.findUnique({
     where: {
       email: email,
+      isDeleted: false,
+      deletedAt: null,
     },
     include: {
       affiliatedCompany: true,


### PR DESCRIPTION
로그인 soft delete 적용

## 📝 요구사항
- `isDeleted` 또는 `deletedAt` 으로 soft delete 된 유저 로그인 막기

## ✨ 변경사항
```typescript
export const getUserByEmail = async (email: string) =>
  await prisma.user.findUnique({
    where: {
      email: email,
      isDeleted: false,
      deletedAt: null,
    },
    include: {
      affiliatedCompany: true,
    },
  });

```

## 🔍 변경 이유


## ✅ 테스트 항목 (선택)


## 🚨 주의 사항


## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #200

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
