### PR TITLE
fix: 차량 삭제 시 연관 계약 데이터 트랜잭션 삭제 처리 추가

### DIFF
--- a/src/controllers/car.controller.ts
+++ b/src/controllers/car.controller.ts
@@ -133,13 +133,16 @@ export const updateCar = async (req: Request, res: Response) => {
 
 // 차량 삭제
 export const deleteCar = async (req: Request, res: Response) => {
-  const id = BigInt(req.params.carId);
+  const user = getUser(req);
+  const companyId = BigInt(user.companyId);
+  const carId = BigInt(req.params.carId);
 
-  const existing = await carService.getCarById(id);
-  if (!existing) throw new NotFoundError('존재하지 않는 차량입니다');
+  const result = await carService.deleteCarCascade(carId, companyId);
 
-  await carService.deleteCar(id);
-  res.status(200).json({ message: '차량 삭제 성공' });
+  res.status(200).json({
+    message: '차량 삭제 성공',
+    carId: result.id,
+  });
 };
 
 // 차량 대용량 업로드

--- a/src/services/car.service.ts
+++ b/src/services/car.service.ts
@@ -2,6 +2,8 @@ import * as carRepo from '../repositories/car.repository';
 import { CarCreateRequest, CarCsvUploadRequest, CarUpdateRequest } from '../types/car.type';
 import { Payload } from '../types/payload.type';
 import { csvToCarList } from '../utils/parse.util';
+import { prisma } from '../utils/prisma.util';
+import { NotFoundError } from '../types/error.type';
 
 // 전체 차량 조회
 export const getAllCars = async () => {
@@ -38,6 +40,51 @@ export const updateCar = async (id: bigint, data: CarUpdateRequest) => {
 // 차량 삭제 (soft delete)
 export const deleteCar = async (id: bigint) => {
   return await carRepo.softDelete(id);
+};
+
+export const deleteCarCascade = async (carId: bigint, companyId: bigint) => {
+  return prisma.$transaction(async (tx) => {
+    // 1) 차량 소유/존재 확인
+    const car = await tx.car.findFirst({
+      where: { id: carId, companyId, isDeleted: false },
+      select: { id: true },
+    });
+    if (!car) throw new NotFoundError('존재하지 않거나 이미 삭제된 차량입니다.');
+
+    // 계약 문서 삭제
+    await tx.contractDocument.deleteMany({
+      where: { contract: { carId } },
+    });
+
+    // 미팅 알람 삭제
+    await tx.alarm.deleteMany({
+      where: { meeting: { contract: { carId } } },
+    });
+
+    // 미팅 삭제
+    await tx.meeting.deleteMany({
+      where: { contract: { carId } },
+    });
+
+    // 계약 소프트 삭제
+    await tx.contract.updateMany({
+      where: { carId },
+      data: { isDeleted: true, deletedAt: new Date() },
+    });
+
+    // 차량 이미지 실제 삭제 (원하면 소프트로 바꿔도 됨)
+    await tx.carImage.deleteMany({
+      where: { carId },
+    });
+
+    // 차량 소프트 삭제
+    await tx.car.update({
+      where: { id: carId },
+      data: { isDeleted: true, deletedAt: new Date() },
+    });
+
+    return { id: Number(carId) };
+  });
 };
 
 // 차량 대용량 업로드


### PR DESCRIPTION
<!-- 제목 예시: [feat] 그룹 등록 API 구현 -->

## 📝 요구사항
<!-- 해당 작업의 기능 요구사항에 대해 작성해주세요 -->
- [x] 차량 삭제 시 해당 차량과 연관된 계약 데이터도 함께 삭제되도록 처리
- [x] 트랜잭션을 활용하여 데이터 정합성 보장

## ✨ 변경사항
<!-- 수정 또는 추가된 사항을 상세히 작성해주세요 -->
- 차량 삭제 API 수정
   - Prisma 트랜잭션(prisma.$transaction) 적용
   - 해당 차량 ID와 연관된 계약(contracts) 삭제 로직 추가
- 기존 단일 deleteCar 로직 → 트랜잭션 기반 삭제로 변경

## 🔍 변경 이유
<!-- 해당 작업을 진행한 이유를 설명해주세요 -->
- 기존에는 차량 삭제 시 연관된 계약 데이터가 남아 데이터 불일치 문제 발생
- 데이터 정합성 확보 및 관리 편의성 향상을 위해 트랜잭션 삭제 처리로 개선

## ✅ 테스트 항목 (선택)
<!-- 수행한 테스트 방법을 작성해주세요 -->
- 차량 삭제 시 연관된 계약 데이터도 함께 삭제되는지 확인
- 계약이 없는 차량 삭제 시 정상 동작 확인

## 🚨 주의 사항
<!-- 리뷰어가 특히 확인해야 할 부분이나 미완성된 부분이 있다면 작성해주세요 -->
- 삭제 처리 후 프론트에서 계약 목록 조회 시 해당 차량의 계약이 보이지 않는지 확인 필요

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #208 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
