### PR TITLE
feat: 회사 검색 기능 개선 및 사용자 조회 쿼리 추가

### DIFF
--- a/src/controllers/company.controller.ts
+++ b/src/controllers/company.controller.ts
@@ -1,7 +1,7 @@
 
 import { Request, Response } from 'express';
 import  * as CompanyService from '../services/company.service';
-import { CompanyCreateRequest, CompanyGetQuery, CompanyUpdateRequest } from '../types/company.type';
+import { CompanyCreateRequest, CompanyGetQuery, CompanyUpdateRequest, UserGetQuery } from '../types/company.type';
 
 /**
  * @description 회사 등록 
@@ -47,8 +47,9 @@ export const getCompanies = async (req: Request, res: Response) => {
   if (keyword && typeof keyword !== 'string') {
     return res.status(400).json({ error: '검색어는 문자열이어야 합니다.' });
   }
-
-  const whereCondition: object = keyword ? { [searchBy]: { contains: keyword } } : {};
+  
+  const searchType = searchBy === 'companyName' ? 'name' : searchBy;
+  const whereCondition: object = keyword ? { [searchType]: { contains: keyword } } : {};
 
   const response = await CompanyService.getCompanies({ page, pageSize, whereCondition });
 
@@ -63,18 +64,20 @@ export const getCompanies = async (req: Request, res: Response) => {
  * @param {string} keyword - 검색어
  */
 export const getUserbyCompany = async (req: Request, res: Response) => {
-  const { page = 1, pageSize = 10, searchBy = 'companyName', keyword }: CompanyGetQuery = req.query;
-  const whereCondition: object = keyword ? { [searchBy]: { contains: keyword } } : {};
+  const { page = 1, pageSize = 10, searchBy = 'companyName', keyword }: UserGetQuery = req.query;
 
   if (page < 1 || pageSize < 1) {
     return res.status(400).json({ error: '페이지 번호와 페이지 크기는 1 이상이어야 합니다.' });
   }
-  if (searchBy && !['companyName', 'companyCode'].includes(searchBy)) {
+  if (searchBy && !['companyName', 'name', 'email'].includes(searchBy)) {
     return res.status(400).json({ error: '유효하지 않은 검색 기준입니다.' });
   }
   if (keyword && typeof keyword !== 'string') {
     return res.status(400).json({ error: '검색어는 문자열이어야 합니다.' });
   }
+  console.log('검색 조건:', { searchBy, keyword });
+  const searchType = searchBy === 'companyName' ? 'company' : searchBy;
+  const whereCondition: object = keyword ? { [searchType]: { contains: keyword } } : {};
 
   const response = await CompanyService.getUserbyCompany({ whereCondition, pageSize, page });
   res.status(200).json(response);

--- a/src/services/company.service.ts
+++ b/src/services/company.service.ts
@@ -35,9 +35,9 @@ export const getCompanies = async ({ whereCondition, pageSize, page }: CompanyLi
   }));
 
   return {
-    page: Number(page),
-    pageSize: Number(pageSize),
-    totalCount,
+    currentPage: Number(page),
+    totalPages: Math.ceil(totalCount / Number(pageSize)),
+    totalItemCount: totalCount,
     data: convertBigIntToString(formattedCompanies),
   };
 };
@@ -60,9 +60,9 @@ export const getUserbyCompany = async ({ whereCondition, pageSize, page }: Compa
   });
 
   return {
-    page: Number(page),
-    pageSize: Number(pageSize),
-    totalCount,
+    currentPage: Number(page),
+    totalPages: Math.ceil(totalCount / Number(pageSize)),
+    totalItemCount: totalCount,
     data: convertBigIntToString(formattedUsers),
   };
 };

--- a/src/types/company.type.ts
+++ b/src/types/company.type.ts
@@ -12,8 +12,12 @@ export type CompanyListRequest = {
 export type CompanyGetQuery = { 
   page?: number; 
   pageSize?: number; 
-  searchBy?: 'companyName' | 'companyCode'; // 더 구체적인 타입
+  searchBy?: 'companyName' | 'companyCode';
   keyword?: string 
+}
+
+export type UserGetQuery = Partial<CompanyGetQuery> & { 
+  searchBy?: 'companyName' | 'name' | 'email';
 }
 
 export type CompanyUpdateRequest = Partial<CompanyCreateRequest>; 


### PR DESCRIPTION
## 📝 요구사항
- [x] 회사 목록에서 기업명과 기업코드로 검색 가능
- [x] 회사 목록에서 페이지네이션 가능
- [x] 유저 목록에서 기업명, 유저이름, 메일로 검색 가능
- [x] 유저 목록에서 페이지네이션 가능

## ✨ 변경사항
- 회사 목록 / 소속유저 목록 응답 필드명 변경
- 응답 페이지 정보 수정
- 유저 검색 쿼리 타입 추가

## 🔍 변경 이유
- 회사 / 소속 유저 목록 출력 시 검색 / 페이지네이션 기능 지원

## ✅ 테스트 항목 (선택)
1. 관리자 계정 접속
2. 회사목록 / 소속유저 목록 출력 확인
3. 검색 타입으로 검색 진행
4. 테이블 아래 페이지네이션으로 데이터 조회 확인

## 🚨 주의 사항
- 테스트 시 관리자 계정으로 접속 필요

## 🔗 관련 이슈 (선택)
- 관련 이슈: #206 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
