### PR TITLE
fix: 이미지 업로드 API 명세서가 아닌 프론트에 맞추기

### DIFF
--- a/src/routes/images.router.ts
+++ b/src/routes/images.router.ts
@@ -6,6 +6,6 @@ import { USER_ROLE } from '../enums/user.enum';
 
 const images = express.Router();
 
-images.post('/upload', allow([USER_ROLE.USER]), imageUploader.single('image'), handleUploadImage);
+images.post('/upload', allow([USER_ROLE.USER]), imageUploader.single('file'), handleUploadImage);
 
 export default images;


### PR DESCRIPTION
이미지 업로드 API 명세서가 아닌 프론트에 맞추기

## 📝 요구사항
- 프론트엔드에 맞춰서 이미지 업로드 구현

## ✨ 변경사항
- `image` -> `file`
**API 명세서**
<img width="855" height="189" alt="스크린샷 2025-08-11 오후 6 56 33" src="https://github.com/user-attachments/assets/73e65d3b-c58a-417a-969d-ac78b4bb90df" />

**프론트엔드 코드**
<img width="1313" height="256" alt="스크린샷 2025-08-11 오후 6 57 08" src="https://github.com/user-attachments/assets/a2ff32bd-c536-48a1-886b-18a835e09fd9" />


## 🔍 변경 이유
<!-- 해당 작업을 진행한 이유를 설명해주세요 -->
- 예시 : 사용자 회원가입 기능 초기 개발

## ✅ 테스트 항목 (선택)


## 🚨 주의 사항


## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #215

## ✅ 체크리스트 
- [ ] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [ ] 코드 리뷰를 위한 설명이 충분한가요?
- [ ] 관련 이슈를 링크했나요?
