### PR TITLE
fix: 비밀번호 업데이트 로직 수정 - 비밀번호 변경인 경우 해시 처리

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -124,7 +124,7 @@ export const updateMyInfo = async (userId: bigint, data: UserUpdateRequest) => {
       throw new ConflictError('이미 존재하는 사원번호입니다.');
     }
   }
-  const hashedPassword = await hash(data.password, 10);
+  const hashedPassword = data.password ? await hash(data.password, 10) : user.password;
   const updatedUser = await UserRepository.updateMyInfo(userId, {
     ...data,
     password: hashedPassword,


### PR DESCRIPTION
## 📝 요구사항
- [x] 사용자 정보 수정 시 employeeNumber, phoneNumber, password, imageUrl 중 선택적으로 수정 가능

## ✨ 변경사항
- 사용자 정보 수정 시 비밀번호 해싱 부분 예외처리

## 🔍 변경 이유
- 비밀번호 변경이 없는 경우 해시 처리 로직에서 에러 발생

## ✅ 테스트 항목 (선택)
- 사용자 정보 수정 시 비밀번호, 사원번호, 휴대폰 번호, 프로필 이미지 선택적으로 수정

## 🚨 주의 사항
- 없음

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #217 

## ✅ 체크리스트 
- [ ] 팀 내 컨벤션이 잘 지켜졌나요?
- [ ] 테스트를 모두 통과했나요?
- [ ] 코드 리뷰를 위한 설명이 충분한가요?
- [ ] 관련 이슈를 링크했나요?
