### PR TITLE
fix: 대시보드 데이터 조회 로직 개선 - 계약 가격 집계 및 타입 정리

### DIFF
--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -9,11 +9,16 @@ export const getDashboard = async (_req: Request, res: Response) => {
   // 현재 날짜
   const currentMonth = new Date();
   // 현재 월의 시작일과 마지막일 계산
-  const startOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
-  const endOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
+  const calCurrentStartDate = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1).toLocaleString();
+  const calCurrentEndDate = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0).toLocaleString();
+  const startOfMonth = new Date(calCurrentStartDate);
+  const endOfMonth = new Date(calCurrentEndDate);
+
   // 지난 월의 시작일과 마지막일 계산
-  const startOfLastMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1);
-  const endOfLastMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 0);
+  const calLastMonthStartDate = new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1).toLocaleString();
+  const calLastMonthEndDate = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 0).toLocaleString();
+  const startOfLastMonth = new Date(calLastMonthStartDate);
+  const endOfLastMonth = new Date(calLastMonthEndDate);
 
   const response: DashboardResponse = await dashboardService.getDashboard({
     startOfMonth,

--- a/src/types/dashboard.type.ts
+++ b/src/types/dashboard.type.ts
@@ -7,17 +7,12 @@ export type DashboardResponse = {
   proceedingContractsCount: number, // 진행 중인 계약 건수
   completedContractsCount: number, // 완료된 계약 건수
   contractsByCarType: ContractsByCarType[],
-  salesByCarType: SalesByCarType[]
+  salesByCarType: ContractsByCarType[]
 }
 
 export type ContractsByCarType = {
   carType: string,
   count: number
-}
-
-export type SalesByCarType = {
-  carType: string,
-  sales: number
 }
 
 // 대시보드 날짜 데이터 타입


### PR DESCRIPTION
## 📝 요구사항
- [x] 계약 성공 시 매출액과 계약 수 등의 집계를 확인할 수 있음

## ✨ 변경사항
- 매출액 계산 로직과 계약 수 집계 로직 수정

## 🔍 변경 이유
- 계약 성공 되어도 계약 수나 매출액 집계 데이터가 표시되지 않음

## ✅ 테스트 항목 (선택)
- 계약 보드에서 계약 상태 수정하며 대시보드 데이터 확인

## 🚨 주의 사항
- 계약이 성공되어야 대시보드 데이터에 반영됨

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #221 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
