### PR TITLE
fix: 차량 imageUrl 업데이트 누락

### DIFF
--- a/src/types/car.type.ts
+++ b/src/types/car.type.ts
@@ -41,6 +41,7 @@ export type CarCreateRequest = {
   accidentDetails?: string;
   type: string;
   status?: string;
+  imageUrl?: string;
   isDeleted?: boolean;   
   deletedAt?: Date | null; 
 };
@@ -62,6 +63,7 @@ export type CarResponse = {
   explanation?: string;
   accidentDetails?: string;
   status: 'possession' | 'contractProceeding' | 'contractCompleted';
+  imageUrl?: string;
 };
 
 // TODO: 통합 고려 CSV 전용 업로드


### PR DESCRIPTION
<!-- 제목 예시: [feat] 그룹 등록 API 구현 -->

## 📝 요구사항
<!-- 해당 작업의 기능 요구사항에 대해 작성해주세요 -->
- [x] 차량 수정 시 업로드된 이미지 URL(imageUrl)이 DB에 정상 저장되어야 한다.
- [x] PATCH /cars/:id 응답에서 최신 imageUrl이 반환되어야 한다.
- [x] 빈 문자열/공백 입력 등 경계값 처리 일관성 유지(선택 필드 null 처리).

## ✨ 변경사항
<!-- 수정 또는 추가된 사항을 상세히 작성해주세요 -->
- Controller (car.controller.ts)
   - 수정 허용 필드 화이트리스트에 imageUrl 추가.
   - 문자열 필드 trim 처리, 선택 필드(explanation, accidentDetails, imageUrl)의 빈 문자열 '' → null 처리.
   - 숫자/BigInt 필드 변환 로직 정리(빈 값은 미수정).
- Service (car.service.ts)
   - imageUrl을 patch에 명시적으로 반영(키가 들어오면 빈 문자열도 포함해서 업데이트).
   - mileage, price, totalPrice를 Prisma BigInt 컬럼에 맞게 변환 후 저장.
   - where: { id }에서 BigInt 그대로 사용(불필요한 Number(id) 제거).
   - accidentCount 검증 보강(0 이상 정수, '' → 0 허용).

## 🔍 변경 이유
<!-- 해당 작업을 진행한 이유를 설명해주세요 -->
- 이미지 업로드 후 “수정”을 눌러도 화면/응답에 구 이미지가 유지되는 문제가 있었음.
- 서비스 레이어에서 imageUrl 필드를 업데이트에 반영하지 않아 DB 값이 갱신되지 않음.
- 추가로 BigInt 컬럼 변환 및 경계값 처리 일관성 개선 필요.

## ✅ 테스트 항목 (선택)
<!-- 수행한 테스트 방법을 작성해주세요 -->
- 이미지 업로드 → PATCH /cars/:id 호출 시 Request Payload에 imageUrl 포함 확인.
- 응답(JSON)에서 imageUrl이 새 URL로 반환되는지 확인.
- accidentCount=''로 전송 시 0으로 저장되는지 확인.
- mileage/price/totalPrice에 정수/문자열 정수 전달 시 BigInt 저장 확인.

## 🚨 주의 사항
<!-- 리뷰어가 특히 확인해야 할 부분이나 미완성된 부분이 있다면 작성해주세요 -->

## 🔗 관련 이슈 (선택)
<!-- 예: Closes #12, Fixes #34 -->
- 관련 이슈: #228 

## ✅ 체크리스트 
- [x] 팀 내 컨벤션이 잘 지켜졌나요?
- [x] 테스트를 모두 통과했나요?
- [x] 코드 리뷰를 위한 설명이 충분한가요?
- [x] 관련 이슈를 링크했나요?
